### PR TITLE
Batch request and spec conformance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,12 @@ tokio-util = { version = "0.7.13", optional = true, features = ["io"] }
 tokio-tungstenite = { version = "0.26.1", features = ["rustls-tls-webpki-roots"], optional = true }
 futures-util = { version = "0.3.31", optional = true }
 
+
+[dev-dependencies]
+tempfile = "3.15.0"
+tracing-subscriber = "0.3.19"
+serial_test = "3.2.0"
+
 [features]
 default = ["axum", "ws", "ipc"]
 axum = ["dep:axum"]
@@ -66,7 +72,3 @@ inherits = "dev"
 strip = true
 debug = false
 incremental = false
-
-[dev-dependencies]
-tempfile = "3.15.0"
-tracing-subscriber = "0.3.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,9 @@ tokio-util = { version = "0.7.13", optional = true, features = ["io"] }
 tokio-tungstenite = { version = "0.26.1", features = ["rustls-tls-webpki-roots"], optional = true }
 futures-util = { version = "0.3.31", optional = true }
 
-
 [dev-dependencies]
 tempfile = "3.15.0"
 tracing-subscriber = "0.3.19"
-serial_test = "3.2.0"
 
 [features]
 default = ["axum", "ws", "ipc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,8 @@ pub mod pubsub;
 pub use pubsub::ReadJsonStream;
 
 mod routes;
+pub use routes::{BatchFuture, Handler, HandlerArgs, HandlerCtx, NotifyError, RouteFuture};
 pub(crate) use routes::{BoxedIntoRoute, ErasedIntoRoute, Method, Route};
-pub use routes::{Handler, HandlerArgs, HandlerCtx, NotifyError, RouteFuture};
 
 mod router;
 pub use router::Router;
@@ -208,7 +208,8 @@ mod test {
                 (),
             )
             .await
-            .expect("infallible");
+            .expect("infallible")
+            .expect("request had ID, is not a notification");
 
         assert_rv_eq(
             &res,
@@ -226,7 +227,8 @@ mod test {
                 (),
             )
             .await
-            .expect("infallible");
+            .expect("infallible")
+            .expect("request had ID, is not a notification");
 
         assert_rv_eq(&res2, r#"{"jsonrpc":"2.0","id":1,"result":"{}"}"#);
     }

--- a/src/pubsub/shared.rs
+++ b/src/pubsub/shared.rs
@@ -192,12 +192,12 @@ where
             select! {
                 biased;
                 _ = write_task.closed() => {
-                    debug!("IpcWriteTask has gone away");
+                    debug!("WriteTask has gone away");
                     break;
                 }
                 item = requests.next() => {
                     let Some(item) = item else {
-                        trace!("IPC read stream has closed");
+                        trace!("inbound read stream has closed");
                         break;
                     };
 
@@ -206,7 +206,7 @@ where
                     // enforces the specification.
                     let reqs = InboundData::try_from(item).unwrap_or_default();
 
-                    let span = debug_span!("ipc request handling", reqs = reqs.len());
+                    let span = debug_span!("pubsub request handling", reqs = reqs.len());
 
                     let ctx = write_task.clone().into();
 

--- a/src/pubsub/shared.rs
+++ b/src/pubsub/shared.rs
@@ -2,8 +2,7 @@ use core::fmt;
 
 use crate::{
     pubsub::{In, JsonSink, Listener, Out},
-    types::Request,
-    HandlerArgs,
+    types::InboundData,
 };
 use serde_json::value::RawValue;
 use tokio::{
@@ -202,22 +201,16 @@ where
                         break;
                     };
 
-                    let req = match Request::try_from(item) {
-                        Ok(req) => req,
-                        Err(err) => {
-                            tracing::warn!(%err, "inbound request is malformatted");
-                            continue
-                        }
-                    };
+                    // If the inbound data is not currently parsable, we
+                    // send an empty one it to the router, as the router
+                    // enforces the specification.
+                    let reqs = InboundData::try_from(item).unwrap_or_default();
 
-                    let span = debug_span!("ipc request handling", id = req.id(), method = req.method());
+                    let span = debug_span!("ipc request handling", reqs = reqs.len());
 
-                    let args = HandlerArgs {
-                        ctx: write_task.clone().into(),
-                        req,
-                    };
+                    let ctx = write_task.clone().into();
 
-                    let fut = router.handle_request(args);
+                    let fut = router.handle_request_batch(ctx, reqs);
                     let write_task = write_task.clone();
 
                     // Acquiring the permit before spawning the task means that
@@ -232,16 +225,14 @@ where
                     // Run the future in a new task.
                     tokio::spawn(
                         async move {
-                            // Run the request handler and serialize the
-                            // response.
-                            let rv = fut.await.expect("infallible");
-
                             // Send the response to the write task.
                             // we don't care if the receiver has gone away,
                             // as the task is done regardless.
-                            let _ = permit.send(
-                                rv
-                            );
+                            if let Some(rv) = fut.await {
+                                let _ = permit.send(
+                                    rv
+                                );
+                            }
                         }
                         .instrument(span)
                     );

--- a/src/routes/ctx.rs
+++ b/src/routes/ctx.rs
@@ -86,17 +86,17 @@ pub struct HandlerArgs {
 
 impl HandlerArgs {
     /// Create new handler arguments.
-    pub fn new(ctx: HandlerCtx, req: Request) -> Self {
+    pub const fn new(ctx: HandlerCtx, req: Request) -> Self {
         Self { ctx, req }
     }
 
     /// Get a reference to the handler context.
-    pub fn ctx(&self) -> &HandlerCtx {
+    pub const fn ctx(&self) -> &HandlerCtx {
         &self.ctx
     }
 
     /// Get a reference to the JSON-RPC request.
-    pub fn req(&self) -> &Request {
+    pub const fn req(&self) -> &Request {
         &self.req
     }
 }

--- a/src/routes/ctx.rs
+++ b/src/routes/ctx.rs
@@ -79,7 +79,24 @@ impl HandlerCtx {
 #[derive(Debug, Clone)]
 pub struct HandlerArgs {
     /// The handler context.
-    pub ctx: HandlerCtx,
+    pub(crate) ctx: HandlerCtx,
     /// The JSON-RPC request.
-    pub req: Request,
+    pub(crate) req: Request,
+}
+
+impl HandlerArgs {
+    /// Create new handler arguments.
+    pub fn new(ctx: HandlerCtx, req: Request) -> Self {
+        Self { ctx, req }
+    }
+
+    /// Get a reference to the handler context.
+    pub fn ctx(&self) -> &HandlerCtx {
+        &self.ctx
+    }
+
+    /// Get a reference to the JSON-RPC request.
+    pub fn req(&self) -> &Request {
+        &self.req
+    }
 }

--- a/src/routes/future.rs
+++ b/src/routes/future.rs
@@ -207,7 +207,7 @@ impl std::future::Future for BatchFuture {
                     // SPEC: single requests return a single response
                     // Batch requests return an array of responses
                     let resp = if *this.single {
-                        this.resps.pop().unwrap_or_else(|| Response::parse_error())
+                        this.resps.pop().unwrap_or_else(Response::parse_error)
                     } else {
                         // otherwise, we have an array of responses
                         serde_json::value::to_raw_value(&this.resps)

--- a/src/routes/future.rs
+++ b/src/routes/future.rs
@@ -1,15 +1,20 @@
-use crate::routes::HandlerArgs;
+use crate::{routes::HandlerArgs, types::RequestError};
 use core::fmt;
 use pin_project::pin_project;
 use serde_json::value::RawValue;
 use std::{
     convert::Infallible,
     future::Future,
-    task::{Context, Poll},
+    panic,
+    task::{ready, Context, Poll},
 };
+use tokio::task::JoinSet;
 use tower::util::{BoxCloneSyncService, Oneshot};
 
-/// A future produced by
+use super::Response;
+
+/// A future produced by [`Router::call_with_state`]. This should only be
+/// instantiated by that method.
 ///
 /// [`Route`]: crate::routes::Route
 #[pin_project]
@@ -18,35 +23,25 @@ pub struct RouteFuture {
     ///
     /// [`Route`]: crate::routes::Route
     #[pin]
-    inner: Oneshot<BoxCloneSyncService<HandlerArgs, Box<RawValue>, Infallible>, HandlerArgs>,
+    inner:
+        Oneshot<BoxCloneSyncService<HandlerArgs, Option<Box<RawValue>>, Infallible>, HandlerArgs>,
     /// The span (if any).
     span: Option<tracing::Span>,
 }
 
 impl RouteFuture {
     /// Create a new route future.
-    pub const fn new(
-        inner: Oneshot<BoxCloneSyncService<HandlerArgs, Box<RawValue>, Infallible>, HandlerArgs>,
+    pub(crate) const fn new(
+        inner: Oneshot<
+            BoxCloneSyncService<HandlerArgs, Option<Box<RawValue>>, Infallible>,
+            HandlerArgs,
+        >,
     ) -> Self {
         Self { inner, span: None }
     }
 
-    /// Create a new method future with a span, this behaves as an
-    /// [`Instrumented`], with the span entered when the future is polled.
-    ///
-    /// [`Instrumented`]: tracing::instrument::Instrumented
-    pub const fn new_with_span(
-        inner: Oneshot<BoxCloneSyncService<HandlerArgs, Box<RawValue>, Infallible>, HandlerArgs>,
-        span: tracing::Span,
-    ) -> Self {
-        Self {
-            inner,
-            span: Some(span),
-        }
-    }
-
     /// Set the span for the future.
-    pub fn with_span(self, span: tracing::Span) -> Self {
+    pub(crate) fn with_span(self, span: tracing::Span) -> Self {
         Self {
             span: Some(span),
             ..self
@@ -61,13 +56,176 @@ impl fmt::Debug for RouteFuture {
 }
 
 impl Future for RouteFuture {
-    type Output = Result<Box<RawValue>, Infallible>;
+    type Output = Result<Option<Box<RawValue>>, Infallible>;
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         let _enter = this.span.as_ref().map(tracing::Span::enter);
 
         this.inner.poll(cx)
+    }
+}
+
+#[pin_project(project = BatchFutureInnerProj)]
+enum BatchFutureInner {
+    Prepping(Vec<RouteFuture>),
+    Running(#[pin] JoinSet<Result<Option<Box<RawValue>>, Infallible>>),
+}
+
+impl BatchFutureInner {
+    fn len(&self) -> usize {
+        match self {
+            Self::Prepping(futs) => futs.len(),
+            Self::Running(futs) => futs.len(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn run(&mut self) {
+        if let Self::Prepping(futs) = self {
+            let js = futs.drain(..).collect::<JoinSet<_>>();
+            *self = Self::Running(js);
+        }
+    }
+}
+
+impl fmt::Debug for BatchFutureInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut s = f.debug_struct("BatchFutureInner");
+
+        match self {
+            Self::Prepping(futs) => s.field("prepared", &futs.len()),
+            Self::Running(futs) => s.field("running", &futs.len()),
+        }
+        .finish_non_exhaustive()
+    }
+}
+
+/// A collection of [`RouteFuture`]s that are executed concurrently.
+///
+/// This is the type returned by [`Router::call_batch_with_state`], and should
+/// only be instantiated by that method.
+///
+/// [`Router::call_batch_with_state`]: crate::Router::call_batch_with_state
+#[pin_project]
+pub struct BatchFuture {
+    /// The futures, either in the prepping or running state.
+    #[pin]
+    futs: BatchFutureInner,
+    /// The responses collected so far.
+    resps: Vec<Box<RawValue>>,
+    /// Whether the batch was a single request.
+    single: bool,
+}
+
+impl fmt::Debug for BatchFuture {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BatchFuture")
+            .field("state", &self.futs)
+            .field("responses", &self.resps.len())
+            .finish()
+    }
+}
+
+impl BatchFuture {
+    /// Create a new batch future with a capacity.
+    pub(crate) fn new_with_capacity(single: bool, capacity: usize) -> Self {
+        Self {
+            futs: BatchFutureInner::Prepping(Vec::with_capacity(capacity)),
+            resps: Vec::with_capacity(capacity),
+            single,
+        }
+    }
+
+    /// Spawn a future into the batch.
+    pub(crate) fn push(&mut self, fut: RouteFuture) {
+        let BatchFutureInner::Prepping(ref mut futs) = self.futs else {
+            panic!("pushing into a running batch future");
+        };
+        futs.push(fut);
+    }
+
+    /// Push a response into the batch.
+    pub(crate) fn push_resp(&mut self, resp: Box<RawValue>) {
+        self.resps.push(resp);
+    }
+
+    /// Push a parse error into the batch.
+    pub(crate) fn push_parse_error(&mut self) {
+        self.push_resp(Response::parse_error());
+    }
+
+    /// Push a parse result into the batch. Convenience function to simplify
+    /// [`Router::call_batch_with_state`] logic.
+    pub(crate) fn push_parse_result(&mut self, result: Result<RouteFuture, RequestError>) {
+        match result {
+            Ok(fut) => self.push(fut),
+            Err(_) => self.push_parse_error(),
+        }
+    }
+}
+
+impl std::future::Future for BatchFuture {
+    type Output = Option<Box<RawValue>>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        if matches!(self.futs, BatchFutureInner::Prepping(_)) {
+            // SPEC: empty arrays are invalid
+            if self.futs.is_empty() {
+                return Poll::Ready(Some(Response::parse_error()));
+            }
+            self.futs.run();
+        }
+
+        let this = self.project();
+        let BatchFutureInnerProj::Running(mut futs) = this.futs.project() else {
+            unreachable!()
+        };
+
+        loop {
+            match ready!(futs.poll_join_next(cx)) {
+                Some(Ok(resp)) => {
+                    // SPEC: notifications receive no response.
+                    if let Some(resp) = unwrap_infallible!(resp) {
+                        this.resps.push(resp);
+                    }
+                }
+
+                // join set is drained, return the response(s)
+                None => {
+                    // SPEC: batches that contain only notifications receive no response.
+                    if this.resps.is_empty() {
+                        return Poll::Ready(None);
+                    }
+
+                    // SPEC: single requests return a single response
+                    // Batch requests return an array of responses
+                    let resp = if *this.single {
+                        this.resps.pop().unwrap_or_else(|| Response::parse_error())
+                    } else {
+                        // otherwise, we have an array of responses
+                        serde_json::value::to_raw_value(&this.resps)
+                            .unwrap_or_else(|_| Response::serialization_failure(RawValue::NULL))
+                    };
+
+                    return Poll::Ready(Some(resp));
+                }
+                // panic in a future, propagate it
+                Some(Err(err)) => {
+                    tracing::error!(?err, "panic or cancel in batch future");
+                    // propagate panics
+                    if let Ok(reason) = err.try_into_panic() {
+                        panic::resume_unwind(reason);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/routes/future.rs
+++ b/src/routes/future.rs
@@ -177,7 +177,7 @@ impl std::future::Future for BatchFuture {
     ) -> std::task::Poll<Self::Output> {
         if matches!(self.futs, BatchFutureInner::Prepping(_)) {
             // SPEC: empty arrays are invalid
-            if self.futs.is_empty() {
+            if self.futs.is_empty() && self.resps.is_empty() {
                 return Poll::Ready(Some(Response::parse_error()));
             }
             self.futs.run();

--- a/src/types/batch.rs
+++ b/src/types/batch.rs
@@ -35,7 +35,7 @@ impl InboundData {
     }
 
     /// Returns true if the batch was a single request, i.e. not an array.
-    pub fn single(&self) -> bool {
+    pub const fn single(&self) -> bool {
         self.single
     }
 }
@@ -55,7 +55,7 @@ impl TryFrom<Bytes> for InboundData {
     fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
         // Special-case a single request, rejecting invalid JSON.
         if bytes.starts_with(b"{") {
-            let rv: &RawValue = serde_json::from_slice(&bytes.as_ref())?;
+            let rv: &RawValue = serde_json::from_slice(bytes.as_ref())?;
 
             let range = find_range!(bytes, rv.get());
 

--- a/src/types/batch.rs
+++ b/src/types/batch.rs
@@ -1,0 +1,85 @@
+use crate::types::{Request, RequestError};
+use bytes::Bytes;
+use serde::Deserialize;
+use serde_json::value::RawValue;
+use std::ops::Range;
+
+/// UTF-8, partially deserialized JSON-RPC request batch.
+#[derive(Default)]
+pub struct InboundData {
+    /// The underlying byte buffer. This is guaranteed to be a validly formatted
+    /// JSON string, containing either a single request or a batch of requests.
+    bytes: Bytes,
+
+    /// Ranges of the `bytes` field that represent the JSON objects in the
+    /// inbound data.
+    reqs: Vec<Range<usize>>,
+
+    /// Whether the batch was a single request. This will be true if the batch
+    /// contained a single JSON object i.e. `{ .. }` and false if it was an
+    /// array.
+    single: bool,
+}
+
+impl InboundData {
+    /// Returns the number of JSON objects in the batch.
+    pub(crate) fn len(&self) -> usize {
+        self.reqs.len()
+    }
+
+    /// Returns an iterator over the requests in the batch.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = Result<Request, RequestError>> + '_ {
+        self.reqs
+            .iter()
+            .map(move |r| Request::try_from(self.bytes.slice(r.clone())))
+    }
+
+    /// Returns true if the batch was a single request, i.e. not an array.
+    pub fn single(&self) -> bool {
+        self.single
+    }
+}
+
+impl core::fmt::Debug for InboundData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BatchReq")
+            .field("bytes", &self.bytes.len())
+            .field("reqs", &self.reqs.len())
+            .finish()
+    }
+}
+
+impl TryFrom<Bytes> for InboundData {
+    type Error = RequestError;
+
+    fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
+        // Special-case a single request, rejecting invalid JSON.
+        if bytes.starts_with(b"{") {
+            let rv: &RawValue = serde_json::from_slice(&bytes.as_ref())?;
+
+            let range = find_range!(bytes, rv.get());
+
+            return Ok(Self {
+                bytes,
+                reqs: vec![range],
+                single: true,
+            });
+        }
+
+        // Otherwise, parse the batch
+        let DeserHelper(reqs) = serde_json::from_slice(bytes.as_ref())?;
+        let reqs = reqs
+            .into_iter()
+            .map(|raw| find_range!(bytes, raw.get()))
+            .collect();
+
+        Ok(Self {
+            bytes,
+            reqs,
+            single: false,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DeserHelper<'a>(#[serde(borrow)] Vec<&'a RawValue>);

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -4,6 +4,7 @@ pub enum RequestError {
     /// Invalid UTF-8
     #[error("Invalid UTF-8: {0}")]
     InvalidUtf8(#[from] core::str::Utf8Error),
+
     /// Invalid JSON
     #[error("Invalid JSON: {0}")]
     InvalidJson(#[from] serde_json::Error),
@@ -28,4 +29,12 @@ pub enum RequestError {
     /// not doing that.
     #[error("Method is too large, limit of 80 bytes. Got: {0}")]
     MethodTooLarge(usize),
+
+    /// Attempted to access an invalid batch index.
+    #[error("Invalid batch index. Attempted to access index {idx}, but only {len} requests are present.")]
+    InvalidBatchIndex { idx: usize, len: usize },
+
+    /// Request is not a JSON object or array.
+    #[error("Request is not a JSON object or array.")]
+    UnexpectedJsonType,
 }

--- a/src/types/macros.rs
+++ b/src/types/macros.rs
@@ -1,0 +1,12 @@
+macro_rules! find_range {
+    ($bytes:expr, $rv:expr) => {{
+        let rv = $rv.as_bytes();
+
+        let start = rv.as_ptr() as usize - $bytes.as_ptr() as usize;
+        let end = start + rv.len();
+
+        debug_assert_eq!(rv, &$bytes[start..end]);
+
+        start..end
+    }};
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,5 +1,11 @@
 //! Core types, like [`Request`] and [`Response`].
 
+#[macro_use]
+mod macros;
+
+mod batch;
+pub(crate) use batch::InboundData;
+
 mod req;
 pub(crate) use req::Request;
 

--- a/src/types/req.rs
+++ b/src/types/req.rs
@@ -139,7 +139,7 @@ impl Request {
     }
 
     /// True if the request is a notification, false otherwise.
-    pub fn is_notification(&self) -> bool {
+    pub const fn is_notification(&self) -> bool {
         self.id.is_none()
     }
 

--- a/src/types/resp.rs
+++ b/src/types/resp.rs
@@ -38,7 +38,7 @@ impl Response<'_, '_, (), ()> {
     /// deserialize into the expected type. This function exists to simplify
     /// notification responses, which should be omitted.
     pub(crate) fn maybe_invalid_params(id: Option<&RawValue>) -> Option<Box<RawValue>> {
-        id.map(|id| Self::invalid_params(id))
+        id.map(Self::invalid_params)
     }
 
     /// Method not found response, used in default fallback handler.
@@ -54,7 +54,7 @@ impl Response<'_, '_, (), ()> {
     /// function exists to simplify notification responses, which should be
     /// omitted.
     pub(crate) fn maybe_method_not_found(id: Option<&RawValue>) -> Option<Box<RawValue>> {
-        id.map(|id| Self::method_not_found(id))
+        id.map(Self::method_not_found)
     }
 
     /// Response failed to serialize

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,8 @@
+use std::time::Duration;
+
 use ajj::{HandlerCtx, Router};
-use serde_json::Value;
-use tokio::time;
+use serde_json::{json, Value};
+use tokio::time::{self, timeout};
 
 /// Instantiate a router for testing.
 pub fn test_router() -> ajj::Router<()> {
@@ -10,13 +12,13 @@ pub fn test_router() -> ajj::Router<()> {
             "double",
             |params: usize| async move { Ok::<_, ()>(params * 2) },
         )
-        .route("notify", |ctx: HandlerCtx| async move {
+        .route("call_me_later", |ctx: HandlerCtx| async move {
             tokio::task::spawn(async move {
                 time::sleep(time::Duration::from_millis(100)).await;
 
                 let _ = ctx
-                    .notify(&serde_json::json!({
-                        "method": "notify",
+                    .notify(&json!({
+                        "method": "call_me_later",
                         "result": "notified"
                     }))
                     .await;
@@ -36,7 +38,7 @@ pub trait TestClient {
 
     async fn send<S: serde::Serialize>(&mut self, method: &str, params: &S) -> usize {
         let id = self.next_id();
-        self.send_raw(&serde_json::json!({
+        self.send_raw(&json!({
             "jsonrpc": "2.0",
             "id": id,
             "method": method,
@@ -47,37 +49,22 @@ pub trait TestClient {
     }
 }
 
-/// basic tests of the test router
-pub async fn basic_tests<T: TestClient>(mut client: T) {
-    test_ping(&mut client).await;
-
-    test_double(&mut client).await;
-
-    test_notify(&mut client).await;
-
-    test_missing_id(&mut client).await;
-}
-
-async fn test_missing_id<T: TestClient>(client: &mut T) {
+// SPEC: notifications receive no response.
+async fn test_notification<T: TestClient>(client: &mut T) {
     client
-        .send_raw(&serde_json::json!(
+        .send_raw(&json!(
             {"jsonrpc": "2.0", "method": "ping"}
         ))
         .await;
 
-    let next: Value = client.recv().await;
-    assert_eq!(
-        next,
-        serde_json::json!({
-            "jsonrpc": "2.0",
-            "result": "pong",
-            "id": null,
-        })
-    );
+    let next: Result<Value, _> = timeout(Duration::from_millis(100), client.recv()).await;
+
+    // The notification should not have a response
+    assert!(next.is_err());
 }
 
-async fn test_notify<T: TestClient>(client: &mut T) {
-    let id = client.send("notify", &()).await;
+async fn test_call_me_later<T: TestClient>(client: &mut T) {
+    let id = client.send("call_me_later", &()).await;
 
     let now = std::time::Instant::now();
 
@@ -91,7 +78,7 @@ async fn test_notify<T: TestClient>(client: &mut T) {
     assert!(now.elapsed().as_millis() >= 100);
     assert_eq!(
         next,
-        serde_json::json!({"method": "notify", "result": "notified"})
+        serde_json::json!({"method": "call_me_later", "result": "notified"})
     );
 }
 
@@ -112,4 +99,116 @@ async fn test_ping<T: TestClient>(client: &mut T) {
         next,
         serde_json::json!({"id": id, "jsonrpc": "2.0", "result": "pong"})
     );
+}
+
+/// basic tests of the test router
+pub async fn basic_tests<T: TestClient>(mut client: T) {
+    test_ping(&mut client).await;
+
+    test_double(&mut client).await;
+
+    test_call_me_later(&mut client).await;
+
+    test_notification(&mut client).await;
+}
+
+/// Test when a full batch request fails to parse
+async fn batch_parse_fail<T: TestClient>(client: &mut T) {
+    client.send_raw(&json!(r#""invalid request""#)).await;
+
+    let next: Value = client.recv().await;
+    assert_eq!(
+        next,
+        serde_json::json!({
+            "id": null,
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32700,
+                "message": "Parse error"
+            }
+        })
+    );
+}
+
+// Test when a single request fails to parse
+async fn batch_single_req_parse_fail<T: TestClient>(client: &mut T) {
+    client
+        .send_raw(&json!([
+            {"jsonrpc": "2.0", "method": "ping", "id": 1},
+            {"jsonrpc": "2.0", "method": "double", "params": 5, "id": 2},
+            {"jsonrpc": "2.0", "method": "ping", "id": 4},
+            "invalid request"
+
+        ]))
+        .await;
+
+    let next: Value = client.recv().await;
+    let arr = next.as_array().unwrap();
+
+    assert_eq!(
+        arr[0],
+        serde_json::json!({
+            "id": null,
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32700,
+                "message": "Parse error"
+            }
+        })
+    );
+
+    assert_eq!(arr.len(), 4);
+    assert!(arr.contains(&serde_json::json!({"id": 1, "jsonrpc": "2.0", "result": "pong"})));
+    assert!(arr.contains(&serde_json::json!({"id": 2, "jsonrpc": "2.0", "result": 10})));
+    assert!(arr.contains(&serde_json::json!({"id": 4, "jsonrpc": "2.0", "result": "pong"})));
+    assert!(arr.contains(&serde_json::json!({
+        "id": null,
+        "jsonrpc": "2.0",
+        "error": {
+            "code": -32700,
+            "message": "Parse error"
+        }
+    })));
+}
+
+// SPEC: notifications receive no response.
+async fn batch_contains_notification<T: TestClient>(client: &mut T) {
+    let batch = json!([
+        {"jsonrpc": "2.0", "method": "ping"},
+        {"jsonrpc": "2.0", "method": "double", "params": 5, "id": 2},
+        {"jsonrpc": "2.0", "method": "ping", "id": 4},
+    ]);
+
+    client.send_raw(&batch).await;
+    let next: Value = client.recv().await;
+
+    let arr = next.as_array().unwrap();
+    assert_eq!(arr.len(), 2);
+    assert!(arr.contains(&serde_json::json!({"id": 2, "jsonrpc": "2.0", "result": 10})));
+    assert!(arr.contains(&serde_json::json!({"id": 4, "jsonrpc": "2.0", "result": "pong"})));
+}
+
+// SPEC: batches that contain only notifications receive no response.
+async fn batch_contains_only_notifications<T: TestClient>(client: &mut T) {
+    let batch = json!([
+        {"jsonrpc": "2.0", "method": "ping"},
+        {"jsonrpc": "2.0", "method": "ping"},
+        {"jsonrpc": "2.0", "method": "ping"},
+    ]);
+
+    client.send_raw(&batch).await;
+    let res = timeout(Duration::from_millis(200), client.recv::<Value>()).await;
+
+    assert!(res.is_err());
+}
+
+/// Test of batch requests
+pub async fn batch_tests<T: TestClient>(mut client: T) {
+    batch_parse_fail(&mut client).await;
+
+    batch_single_req_parse_fail(&mut client).await;
+
+    batch_contains_notification(&mut client).await;
+
+    batch_contains_only_notifications(&mut client).await;
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -102,14 +102,14 @@ async fn test_ping<T: TestClient>(client: &mut T) {
 }
 
 /// basic tests of the test router
-pub async fn basic_tests<T: TestClient>(mut client: T) {
-    test_ping(&mut client).await;
+pub async fn basic_tests<T: TestClient>(client: &mut T) {
+    test_ping(client).await;
 
-    test_double(&mut client).await;
+    test_double(client).await;
 
-    test_call_me_later(&mut client).await;
+    test_call_me_later(client).await;
 
-    test_notification(&mut client).await;
+    test_notification(client).await;
 }
 
 /// Test when a full batch request fails to parse
@@ -203,12 +203,12 @@ async fn batch_contains_only_notifications<T: TestClient>(client: &mut T) {
 }
 
 /// Test of batch requests
-pub async fn batch_tests<T: TestClient>(mut client: T) {
-    batch_parse_fail(&mut client).await;
+pub async fn batch_tests<T: TestClient>(client: &mut T) {
+    batch_parse_fail(client).await;
 
-    batch_single_req_parse_fail(&mut client).await;
+    batch_single_req_parse_fail(client).await;
 
-    batch_contains_notification(&mut client).await;
+    batch_contains_notification(client).await;
 
-    batch_contains_only_notifications(&mut client).await;
+    batch_contains_only_notifications(client).await;
 }

--- a/tests/ipc.rs
+++ b/tests/ipc.rs
@@ -27,8 +27,7 @@ async fn serve_ipc() -> (ServerShutdown, TempPath) {
     let temp = NamedTempFile::new().unwrap().into_temp_path();
     let name = to_name(temp.as_os_str()).unwrap();
 
-    dbg!(&name);
-    dbg!(std::fs::remove_file(&temp).unwrap());
+    std::fs::remove_file(&temp).unwrap();
 
     let shutdown = ListenerOptions::new()
         .name(name)
@@ -88,4 +87,12 @@ async fn basic_ipc() {
     let client = IpcClient::new(&temp).await;
 
     common::basic_tests(client).await;
+}
+
+#[tokio::test]
+async fn batch_ipc() {
+    let (_server, temp) = serve_ipc().await;
+    let client = IpcClient::new(&temp).await;
+
+    common::batch_tests(client).await;
 }

--- a/tests/ipc.rs
+++ b/tests/ipc.rs
@@ -82,17 +82,10 @@ impl TestClient for IpcClient {
 }
 
 #[tokio::test]
-async fn basic_ipc() {
+async fn test_ipc() {
     let (_server, temp) = serve_ipc().await;
-    let client = IpcClient::new(&temp).await;
+    let mut client = IpcClient::new(&temp).await;
 
-    common::basic_tests(client).await;
-}
-
-#[tokio::test]
-async fn batch_ipc() {
-    let (_server, temp) = serve_ipc().await;
-    let client = IpcClient::new(&temp).await;
-
-    common::batch_tests(client).await;
+    common::basic_tests(&mut client).await;
+    common::batch_tests(&mut client).await;
 }

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -65,17 +65,9 @@ async fn ws_client() -> WsClient {
 
 #[tokio::test]
 #[serial]
-async fn basic_ws() {
+async fn test_ws() {
     let _server = serve_ws().await;
-    let client = ws_client().await;
-    common::basic_tests(client).await;
-}
-
-#[tokio::test]
-#[serial]
-async fn batch_ws() {
-    let _server = serve_ws().await;
-    let client = ws_client().await;
-
-    common::batch_tests(client).await;
+    let mut client = ws_client().await;
+    common::basic_tests(&mut client).await;
+    common::batch_tests(&mut client).await;
 }

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -3,7 +3,6 @@ use common::{test_router, TestClient};
 
 use ajj::pubsub::{Connect, ServerShutdown};
 use futures_util::{SinkExt, StreamExt};
-use serial_test::serial;
 use std::net::{Ipv4Addr, SocketAddr};
 use tokio_tungstenite::{
     tungstenite::{client::IntoClientRequest, Message},
@@ -64,7 +63,6 @@ async fn ws_client() -> WsClient {
 }
 
 #[tokio::test]
-#[serial]
 async fn test_ws() {
     let _server = serve_ws().await;
     let mut client = ws_client().await;

--- a/tests/ws.rs
+++ b/tests/ws.rs
@@ -3,6 +3,7 @@ use common::{test_router, TestClient};
 
 use ajj::pubsub::{Connect, ServerShutdown};
 use futures_util::{SinkExt, StreamExt};
+use serial_test::serial;
 use std::net::{Ipv4Addr, SocketAddr};
 use tokio_tungstenite::{
     tungstenite::{client::IntoClientRequest, Message},
@@ -63,8 +64,18 @@ async fn ws_client() -> WsClient {
 }
 
 #[tokio::test]
+#[serial]
 async fn basic_ws() {
     let _server = serve_ws().await;
     let client = ws_client().await;
     common::basic_tests(client).await;
+}
+
+#[tokio::test]
+#[serial]
+async fn batch_ws() {
+    let _server = serve_ws().await;
+    let client = ws_client().await;
+
+    common::batch_tests(client).await;
 }


### PR DESCRIPTION
Closes #8

Updated notification handling to conform to spec by omitting responses when the ID field is omitted

These changes are almost entirely internal