### PR TITLE
refactor: improve and document handler type inference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "Simple, modern, ergonomic JSON-RPC 2.0 router built with tower an
 keywords = ["json-rpc", "jsonrpc", "json"]
 categories = ["web-programming::http-server", "web-programming::websocket"]
 
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4", "James Prestwich"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,17 @@
 //! register JSON-RPC methods and their handlers.
 //!
 //! ```no_run
-//! use ajj::{Router, HandlerCtx, ResponsePayload, Params};
+//! use ajj::{Router, HandlerCtx, ResponsePayload};
 //!
-//! # fn main() {
+//! # fn test_fn() -> Router<()> {
 //! // Provide methods called "double" and "add" to the router.
 //! let router = Router::<u64>::new()
-//!   .route("double", |Params(params): Params<u64>| async move {
-//!     Ok::<_, ()>(params * 2)
-//!   })
 //!   .route("add", |params: u64, state: u64| async move {
 //!     Ok::<_, ()>(params + state)
+//!   })
+//!   .with_state(3u64)
+//!   .route("double", |params: u64| async move {
+//!     Ok::<_, ()>(params * 2)
 //!   })
 //!   // Routes get a ctx, which can be used to send notifications.
 //!   .route("notify", |ctx: HandlerCtx| async move {
@@ -43,9 +44,8 @@
 //!   .route("error_example", || async {
 //!     // This will appear in the ResponsePayload's `message` field.
 //!     ResponsePayload::<(), ()>::internal_error_message("this is an error".into())
-//!   })
-//!   // The router is provided with state, and is now ready to serve requests.
-//!   .with_state::<()>(3u64);
+//!   });
+//! # router
 //! # }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,9 @@ pub mod pubsub;
 pub use pubsub::ReadJsonStream;
 
 mod routes;
-pub use routes::{BatchFuture, Handler, HandlerArgs, HandlerCtx, NotifyError, RouteFuture};
+pub use routes::{
+    BatchFuture, Handler, HandlerArgs, HandlerCtx, NotifyError, Params, RouteFuture, State,
+};
 pub(crate) use routes::{BoxedIntoRoute, ErasedIntoRoute, Method, Route};
 
 mod router;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,12 @@
 //! register JSON-RPC methods and their handlers.
 //!
 //! ```no_run
-//! use ajj::{Router, HandlerCtx, ResponsePayload};
+//! use ajj::{Router, HandlerCtx, ResponsePayload, Params};
 //!
 //! # fn main() {
 //! // Provide methods called "double" and "add" to the router.
 //! let router = Router::<u64>::new()
-//!   .route("double", |params: u64| async move {
+//!   .route("double", |Params(params): Params<u64>| async move {
 //!     Ok::<_, ()>(params * 2)
 //!   })
 //!   .route("add", |params: u64, state: u64| async move {

--- a/src/router.rs
+++ b/src/router.rs
@@ -36,12 +36,14 @@ use tracing::{debug_span, trace};
 /// These methods can
 ///
 /// ```
-/// use ajj::{Router};
+/// use ajj::{Router, Params};
 ///
 /// # fn main() {
 /// // Provide methods called "double" and "add" to the router.
 /// let router = Router::<u64>::new()
-///   .route("double", |params: u64| async move {
+///   // when double is called, the provided number is doubled.
+///   // see the Handler docs for more information on the hint type
+///   .route("double", |Params(params): Params<u64>| async move {
 ///     Ok::<_, ()>(params * 2)
 ///   })
 ///   .route("add", |params: u64, state: u64| async move {

--- a/src/router.rs
+++ b/src/router.rs
@@ -33,27 +33,24 @@ use tracing::{debug_span, trace};
 /// The `double` method doubles the provided number, and the `add` method adds
 /// the provided number to some state, and returns the sum.
 ///
-/// These methods can
-///
 /// ```
-/// use ajj::{Router, Params};
+/// use ajj::Router;
 ///
 /// # fn main() {
 /// // Provide methods called "double" and "add" to the router.
 /// let router = Router::<u64>::new()
-///   // when double is called, the provided number is doubled.
-///   // see the Handler docs for more information on the hint type
-///   .route("double", |Params(params): Params<u64>| async move {
-///     Ok::<_, ()>(params * 2)
-///   })
+///    // This route requires state to be provided.
 ///   .route("add", |params: u64, state: u64| async move {
 ///     Ok::<_, ()>(params + state)
 ///   })
-///   // The router is provided with state, and is now ready to serve requests.
-///   .with_state::<()>(3u64);
+///   .with_state::<()>(3u64)
+///   // when double is called, the provided number is doubled.
+///   // see the Handler docs for more information on the hint type
+///   .route("double", |params: u64| async move {
+///     Ok::<_, ()>(params * 2)
+///   });
 /// # }
 /// ```
-///
 ///
 /// ## Note
 ///

--- a/src/routes/future.rs
+++ b/src/routes/future.rs
@@ -13,10 +13,9 @@ use tower::util::{BoxCloneSyncService, Oneshot};
 
 use super::Response;
 
-/// A future produced by [`Router::call_with_state`]. This should only be
-/// instantiated by that method.
+/// A future produced by the [`Router`].
 ///
-/// [`Route`]: crate::routes::Route
+/// [`Router`]: crate::Router
 #[pin_project]
 pub struct RouteFuture {
     /// The inner [`Route`] future.
@@ -159,7 +158,9 @@ impl BatchFuture {
     }
 
     /// Push a parse result into the batch. Convenience function to simplify
-    /// [`Router::call_batch_with_state`] logic.
+    /// [`Router`] logic.
+    ///
+    /// [`Router`]: crate::Router
     pub(crate) fn push_parse_result(&mut self, result: Result<RouteFuture, RequestError>) {
         match result {
             Ok(fut) => self.push(fut),

--- a/src/routes/handler.rs
+++ b/src/routes/handler.rs
@@ -60,9 +60,9 @@ pub struct PhantomParams<T>(PhantomData<T>);
 /// whether a handler argument is `params` or `state`:
 ///
 /// 1. The handler takes EITHER `params` or `state`.
-/// 2. The `S` type of the router is a valid `params` type (i.e. it impls
-///   [`serde::de::DeserializeOwned`] and satisfies the other requirements of
-///   [`RpcRecv`]).
+/// 2. The `S` type of the router would also be a valid `Params` type (i.e. it
+///   impls [`DeserializeOwned`] and satisfies the other
+///   requirements of [`RpcRecv`]).
 /// 3. The argument to the handler matches the `S` type of the router.
 ///
 /// ```compile_fail
@@ -110,11 +110,12 @@ pub struct PhantomParams<T>(PhantomData<T>);
 ///     // This was already unambiguous, as having both `params` and `state` is
 ///     // never ambiguous
 ///     .route("baz", |params: u8, state: u8| ok())
-///     .with_state::<()>(3u8)
 ///
 ///     // "bar" presents a problem. We'll come back to this in the next
 ///     // example.
 ///     // .route("bar", |state: u8| ok())
+///
+///     .with_state::<()>(3u8)
 ///
 ///     // `S` is now `()`, so the argument is unambiguous.
 ///     .route("foo", |params: u8| ok())
@@ -280,6 +281,8 @@ pub struct PhantomParams<T>(PhantomData<T>);
 ///   }
 /// }
 /// ```
+///
+/// [`DeserializeOwned`]: serde::de::DeserializeOwned
 #[cfg_attr(feature = "pubsub", doc = " [`Listener`]: crate::pubsub::Listener")]
 pub trait Handler<T, S>: Clone + Send + Sync + Sized + 'static {
     /// The future returned by the handler.

--- a/src/routes/handler.rs
+++ b/src/routes/handler.rs
@@ -83,6 +83,8 @@ pub struct PhantomParams<T>(PhantomData<T>);
 ///     .route("bar", |state: u8| ok())
 ///     // "baz" is unambiguous, as it has both `params` and `state` arguments
 ///     .route("baz", |params: u8, state: u8| ok())
+///     // this is unambiguous, but a bit ugly.
+///     .route("qux", |params: u8, _: u8| ok())
 ///     .with_state(3u8)
 /// # }
 /// ```
@@ -125,7 +127,7 @@ pub struct PhantomParams<T>(PhantomData<T>);
 /// However this still leaves the problem of "bar". There is no way to express
 /// "bar" unambiguously by reordering method invocations. In this case, you can
 /// use the [`Params`] and [`State`] wrapper structs to disambiguate the
-/// argument type.
+/// argument type. This should seem familiar to users of [`axum`].
 ///
 /// ```
 /// # use ajj::{Router, Params, State};
@@ -148,7 +150,8 @@ pub struct PhantomParams<T>(PhantomData<T>);
 /// ```
 ///
 /// These wrapper structs are available only when necessary, and may not be
-/// used when the `Handler` impl is unambiguous.
+/// used when the `Handler` impl is unambiguous. Ambiguous handlers will always
+/// result in a compilation error.
 ///
 /// ### Handler return type inference
 ///

--- a/src/routes/handler.rs
+++ b/src/routes/handler.rs
@@ -134,9 +134,11 @@ pub struct PhantomParams<T>(PhantomData<T>);
 ///     // This is now unambiguous, as the `Params` wrapper indicates that the
 ///     // argument is `params`
 ///     .route("foo", |Params(params): Params<u8>| ok())
+///
 ///     // This is now umabiguous, as the `State` wrapper indicates that the
 ///     // argument is `state`
 ///     .route("bar", |State(state): State<u8>| ok())
+///
 ///     // This was already unambiguous, as having both `params` and `state` is
 ///     // never ambiguous
 ///     .route("baz", |params: u8, state: u8| ok())

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -8,8 +8,8 @@ mod future;
 pub use future::{BatchFuture, RouteFuture};
 
 mod handler;
-pub use handler::Handler;
 pub(crate) use handler::HandlerInternal;
+pub use handler::{Handler, Params, State};
 
 mod method;
 pub(crate) use method::Method;

--- a/src/types/resp.rs
+++ b/src/types/resp.rs
@@ -203,6 +203,18 @@ impl<Payload, ErrData> ResponsePayload<Payload, ErrData> {
     pub const fn is_error(&self) -> bool {
         matches!(self, Self::Failure(_))
     }
+
+    /// Convert a result into a response payload, by converting the error into
+    /// an internal error message.
+    pub fn convert_internal_error_msg<T>(res: Result<Payload, T>) -> Self
+    where
+        T: Into<Cow<'static, str>>,
+    {
+        match res {
+            Ok(payload) => Self::Success(payload),
+            Err(err) => Self::Failure(ErrorPayload::internal_error_message(err.into())),
+        }
+    }
 }
 
 /// A JSON-RPC 2.0 error object.


### PR DESCRIPTION
This adds some missing handler impls and adds disambiguation types to give the compiler hints about which impl to use