### PR TITLE
refactor: improve tracing span usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "Simple, modern, ergonomic JSON-RPC 2.0 router built with tower an
 keywords = ["json-rpc", "jsonrpc", "json"]
 categories = ["web-programming::http-server", "web-programming::websocket"]
 
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4", "James Prestwich"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 rust-version = "1.81"
 authors = ["init4", "James Prestwich"]
 license = "MIT OR Apache-2.0"
-homepage = "https://github.com/init4tech/rpc"
-repository = "https://github.com/init4tech/rpc"
+homepage = "https://github.com/init4tech/ajj"
+repository = "https://github.com/init4tech/ajj"
 
 [dependencies]
 bytes = "1.9.0"

--- a/src/router.rs
+++ b/src/router.rs
@@ -316,7 +316,7 @@ where
         let mut fut = BatchFuture::new_with_capacity(inbound.single(), inbound.len());
         // According to spec, non-parsable requests should still receive a
         // response.
-        let span = debug_span!(parent: None, "BatchFuture::poll", futs = fut.len());
+        let span = debug_span!(parent: None, "BatchFuture::poll", reqs = inbound.len(), futs = tracing::field::Empty);
 
         for (batch_idx, req) in inbound.iter().enumerate() {
             let req = req.map(|req| {
@@ -328,6 +328,7 @@ where
             });
             fut.push_parse_result(req);
         }
+        span.record("futs", fut.len());
         fut.with_span(span)
     }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -320,7 +320,7 @@ where
 
         for (batch_idx, req) in inbound.iter().enumerate() {
             let req = req.map(|req| {
-                let span = debug_span!("RouteFuture::poll", batch_idx, method = req.method(), id = ?req.id());
+                let span = debug_span!(parent: &span, "RouteFuture::poll", batch_idx, method = req.method(), id = ?req.id());
                 let args = HandlerArgs::new(ctx.clone(), req);
                 self.inner
                     .call_with_state(args, state.clone())

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -20,6 +20,7 @@ use std::{
     task::{Context, Poll},
 };
 use tower::{util::BoxCloneSyncService, Service, ServiceExt};
+use tracing::{debug_span, enabled, Level};
 
 use crate::types::Response;
 
@@ -95,6 +96,14 @@ impl Service<HandlerArgs> for Route {
     }
 
     fn call(&mut self, args: HandlerArgs) -> Self::Future {
+        let span = debug_span!(
+            "Route::call",
+            notifications_enabled = args.ctx().notifications_enabled(),
+            params = tracing::field::Empty,
+        );
+        if enabled!(Level::TRACE) {
+            span.record("params", args.req.params());
+        }
         self.oneshot_inner(args)
     }
 }

--- a/src/types/batch.rs
+++ b/src/types/batch.rs
@@ -56,7 +56,7 @@ impl TryFrom<Bytes> for InboundData {
     #[instrument(level = "debug", skip(bytes), fields(buf_len = bytes.len(), bytes = tracing::field::Empty))]
     fn try_from(bytes: Bytes) -> Result<Self, Self::Error> {
         if enabled!(Level::TRACE) {
-            tracing::span::Span::current().record("bytes", &format!("0x{:x}", bytes));
+            tracing::span::Span::current().record("bytes", format!("0x{:x}", bytes));
         }
         debug!("Parsing inbound data");
 

--- a/src/types/req.rs
+++ b/src/types/req.rs
@@ -2,6 +2,7 @@ use crate::types::{RequestError, ID_LEN_LIMIT, METHOD_LEN_LIMIT};
 use bytes::Bytes;
 use serde_json::value::RawValue;
 use std::ops::Range;
+use tracing::trace;
 
 /// Utf8 payload, partially deserialized
 #[derive(Clone)]
@@ -183,7 +184,9 @@ impl Request {
     pub fn deser_params<'a: 'de, 'de, T: serde::Deserialize<'de>>(
         &'a self,
     ) -> serde_json::Result<T> {
-        serde_json::from_str(self.params()).inspect_err(|err| tracing::debug!(%err, expected = std::any::type_name::<T>(), "failed to parse params"))
+        serde_json::from_str(self.params()).inspect_err(
+            |err| trace!(%err, expected = std::any::type_name::<T>(), "failed to parse params"),
+        )
     }
 }
 

--- a/src/types/req.rs
+++ b/src/types/req.rs
@@ -183,7 +183,7 @@ impl Request {
     pub fn deser_params<'a: 'de, 'de, T: serde::Deserialize<'de>>(
         &'a self,
     ) -> serde_json::Result<T> {
-        serde_json::from_str(self.params())
+        serde_json::from_str(self.params()).inspect_err(|err| tracing::debug!(%err, expected = std::any::type_name::<T>(), "failed to parse params"))
     }
 }
 


### PR DESCRIPTION
Makes a few span usage changes

- adds verbose event for param parsing failures in `Level::TRACE`
- adds root spans for request and batch request handling in router
- removes permanently-open spans for tasks
- moves future instantiation after permit acquisition to delay resource allocation
- adds `span` to `BatchFuture` so that all `RouteFutures` are inside the batch future
- add spans that record the params before decoding, and before deserialization