### PR TITLE
feat: convenience methods for axum ws

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "Simple, modern, ergonomic JSON-RPC 2.0 router built with tower an
 keywords = ["json-rpc", "jsonrpc", "json"]
 categories = ["web-programming::http-server", "web-programming::websocket"]
 
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4", "James Prestwich"]


### PR DESCRIPTION
Adds several convenience methods to `Router` for serving the router over axum ws


```
Router::to_axum_cfg
Router::into_axum_with_ws
Router::into_axum_with_ws_and_handler
```