### PR TITLE
fix(`types`): conform JSON-RPC parsing to spec by properly trimming whitespace and newlines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "Simple, modern, ergonomic JSON-RPC 2.0 router built with tower an
 keywords = ["json-rpc", "jsonrpc", "json"]
 categories = ["web-programming::http-server", "web-programming::websocket"]
 
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4", "James Prestwich"]

--- a/src/types/batch.rs
+++ b/src/types/batch.rs
@@ -61,6 +61,11 @@ impl TryFrom<Bytes> for InboundData {
         }
         debug!("Parsing inbound data");
 
+        // Trim whitespace from the input bytes. This is necessary to ensure that
+        // we can parse the input as a JSON string. The JSON spec allows for
+        // whitespace before and after the JSON string.
+        // Sadly [`Bytes::trim_ascii`] does not remove linebreaks, so we have to
+        // convert to a str and trim it.
         let bytes = Bytes::from(str::from_utf8(bytes.as_ref())?.trim().to_owned());
 
         // Special-case a single request, rejecting invalid JSON.

--- a/src/types/req.rs
+++ b/src/types/req.rs
@@ -192,6 +192,7 @@ impl Request {
 
 #[cfg(test)]
 mod test {
+
     use crate::types::METHOD_LEN_LIMIT;
 
     use super::*;
@@ -235,5 +236,29 @@ mod test {
         };
 
         assert_eq!(size, METHOD_LEN_LIMIT + 1);
+    }
+
+    #[test]
+    fn test_with_linebreak() {
+        let bytes = Bytes::from_static(
+            r#"
+       
+   { "id": 1,
+    "jsonrpc": "2.0",
+    "method": "eth_getBalance",
+    "params": ["0x4444d38c385d0969C64c4C8f996D7536d16c28B9", "latest"]
+  }
+
+        "#
+            .as_bytes(),
+        );
+        let req = Request::try_from(bytes).unwrap();
+
+        assert_eq!(req.id(), Some("1"));
+        assert_eq!(req.method(), r#"eth_getBalance"#);
+        assert_eq!(
+            req.params(),
+            r#"["0x4444d38c385d0969C64c4C8f996D7536d16c28B9", "latest"]"#
+        );
     }
 }


### PR DESCRIPTION
Right now we're technically off spec from JSON-RPC, as we don't trim whitespace or newlines at all from any incoming requests, but we should. This leads to problems like making it more cumbersome to use `curl` to create raw requests to routers that use ajj.

`serde_json` handles this just fine. The fix is roughly to use `serde_json` to parse the bytes and check through it's `RawValue` to see if it's a batch or not.
