### PR TITLE
feat!: add IntoErrorPayload trait for structured JSON-RPC errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+/docs
 */.DS_Store
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,7 @@ required-features = ["axum", "pubsub"]
 [[example]]
 name = "cors"
 required-features = ["axum"]
+
+[[example]]
+name = "magic8ball"
+required-features = ["axum"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "Simple, modern, ergonomic JSON-RPC 2.0 router built with tower an
 keywords = ["json-rpc", "jsonrpc", "json"]
 categories = ["web-programming::http-server", "web-programming::websocket"]
 
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4", "James Prestwich"]

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -32,7 +32,7 @@ fn make_router() -> ajj::Router<()> {
         .route("notify", |ctx: HandlerCtx| async move {
             // Check if notifications are enabled for the connection.
             if !ctx.notifications_enabled() {
-                // This error will appear in the ResponsePayload's `data` field.
+                // This error will appear in the ResponsePayload's `message` field.
                 return Err("notifications are disabled");
             }
 

--- a/examples/ipc.rs
+++ b/examples/ipc.rs
@@ -53,7 +53,7 @@ fn make_router() -> Router<()> {
         .route("notify", |ctx: HandlerCtx| async move {
             // Check if notifications are enabled for the connection.
             if !ctx.notifications_enabled() {
-                // This error will appear in the ResponsePayload's `data` field.
+                // This error will appear in the ResponsePayload's `message` field.
                 return Err("notifications are disabled");
             }
 

--- a/examples/magic8ball.rs
+++ b/examples/magic8ball.rs
@@ -1,0 +1,236 @@
+//! Magic 8-Ball JSON-RPC server.
+//!
+//! A mystical fortune-telling service with structured error codes for
+//! different cosmic failure modes.
+//!
+//! ## Methods
+//!
+//! - `shakeBall` — Ask a yes/no question, receive a fortune.
+//! - `readAura` — Read the cosmic aura for a named querent.
+//! - `consultStars` — Check planetary alignment for a zodiac sign.
+
+use ajj::{ErrorPayload, IntoErrorPayload, Router};
+use serde::Serialize;
+use std::borrow::Cow;
+
+// ── Fortunes ────────────────────────────────────────────────────────
+
+const POSITIVE: &[&str] = &[
+    "It is certain.",
+    "Without a doubt.",
+    "You may rely on it.",
+    "Yes, definitely.",
+    "As I see it, yes.",
+];
+
+const NEGATIVE: &[&str] = &[
+    "Don't count on it.",
+    "My reply is no.",
+    "My sources say no.",
+    "Very doubtful.",
+];
+
+const NEUTRAL: &[&str] = &[
+    "Reply hazy, try again.",
+    "Ask again later.",
+    "Better not tell you now.",
+    "Cannot predict now.",
+    "Concentrate and ask again.",
+];
+
+fn pick<'a>(choices: &'a [&'a str], seed: u64) -> &'a str {
+    choices[(seed as usize) % choices.len()]
+}
+
+fn cheap_hash(s: &str) -> u64 {
+    s.bytes()
+        .fold(5381u64, |h, b| h.wrapping_mul(33).wrapping_add(b as u64))
+}
+
+// ── Error types ─────────────────────────────────────────────────────
+
+/// Structured data returned when the crystal ball is cloudy.
+#[derive(Debug, Serialize)]
+struct CloudyDetail {
+    visibility: &'static str,
+    suggestion: &'static str,
+}
+
+/// Structured data for planetary misalignment.
+#[derive(Debug, Serialize)]
+struct MisalignmentDetail {
+    sign: String,
+    interfering_planet: &'static str,
+}
+
+/// All the ways a mystical consultation can fail.
+#[derive(Debug)]
+enum MysticError {
+    /// The crystal ball is too cloudy to read.
+    CrystalBallCloudy,
+    /// The stars are not aligned for this query.
+    StarsMisaligned { sign: String },
+    /// Mercury is in retrograde — all bets are off.
+    MercuryRetrograde,
+    /// The querent's aura is unreadable.
+    UnreadableAura(String),
+}
+
+impl IntoErrorPayload for MysticError {
+    type ErrData = Box<serde_json::value::RawValue>;
+
+    fn error_code(&self) -> i64 {
+        match self {
+            Self::CrystalBallCloudy => -32001,
+            Self::StarsMisaligned { .. } => -32002,
+            Self::MercuryRetrograde => -32003,
+            Self::UnreadableAura(_) => -32004,
+        }
+    }
+
+    fn error_message(&self) -> Cow<'static, str> {
+        match self {
+            Self::CrystalBallCloudy => "Crystal ball is cloudy".into(),
+            Self::StarsMisaligned { sign } => format!("Stars misaligned for {sign}").into(),
+            Self::MercuryRetrograde => "Mercury is in retrograde".into(),
+            Self::UnreadableAura(name) => format!("Cannot read aura of {name}").into(),
+        }
+    }
+
+    fn into_error_payload(self) -> ErrorPayload<Box<serde_json::value::RawValue>> {
+        let code = self.error_code();
+        let message = self.error_message();
+        let data = match &self {
+            Self::CrystalBallCloudy => serde_json::value::to_raw_value(&CloudyDetail {
+                visibility: "opaque",
+                suggestion: "try polishing the ball",
+            })
+            .ok(),
+            Self::StarsMisaligned { sign } => {
+                serde_json::value::to_raw_value(&MisalignmentDetail {
+                    sign: sign.clone(),
+                    interfering_planet: "Saturn",
+                })
+                .ok()
+            }
+            Self::MercuryRetrograde | Self::UnreadableAura(_) => None,
+        };
+        ErrorPayload {
+            code,
+            message,
+            data,
+        }
+    }
+}
+
+// ── Handlers ────────────────────────────────────────────────────────
+
+/// Shake the Magic 8-Ball with a yes/no question.
+async fn shake_ball(question: String) -> Result<String, MysticError> {
+    if question.is_empty() {
+        return Err(MysticError::CrystalBallCloudy);
+    }
+
+    let h = cheap_hash(&question);
+    let fortune = match h % 3 {
+        0 => pick(POSITIVE, h),
+        1 => pick(NEGATIVE, h),
+        _ => pick(NEUTRAL, h),
+    };
+    Ok(fortune.to_string())
+}
+
+/// Read the cosmic aura for a named querent.
+async fn read_aura(name: String) -> Result<String, MysticError> {
+    if name.len() < 2 {
+        return Err(MysticError::UnreadableAura(name));
+    }
+
+    let h = cheap_hash(&name);
+    let colors = ["violet", "indigo", "gold", "emerald", "crimson", "silver"];
+    let intensity = ["faint", "steady", "brilliant", "pulsing", "radiant"];
+
+    Ok(format!(
+        "{}'s aura is {} {}",
+        name,
+        intensity[(h as usize) % intensity.len()],
+        colors[(h as usize / 7) % colors.len()],
+    ))
+}
+
+/// Check planetary alignment for a zodiac sign.
+async fn consult_stars(sign: String) -> Result<String, MysticError> {
+    let valid = [
+        "aries",
+        "taurus",
+        "gemini",
+        "cancer",
+        "leo",
+        "virgo",
+        "libra",
+        "scorpio",
+        "sagittarius",
+        "capricorn",
+        "aquarius",
+        "pisces",
+    ];
+
+    let lower = sign.to_lowercase();
+    if !valid.contains(&lower.as_str()) {
+        return Err(MysticError::StarsMisaligned { sign });
+    }
+
+    // Mercury retrograde hits Gemini and Virgo (Mercury-ruled signs)
+    if lower == "gemini" || lower == "virgo" {
+        return Err(MysticError::MercuryRetrograde);
+    }
+
+    let h = cheap_hash(&lower);
+    let forecasts = [
+        "The cosmos smile upon you today.",
+        "A journey of great importance awaits.",
+        "Trust the process — transformation is near.",
+        "An unexpected ally will appear.",
+        "Financial winds blow in your favor.",
+    ];
+
+    Ok(format!(
+        "{}: {}",
+        sign,
+        forecasts[(h as usize) % forecasts.len()]
+    ))
+}
+
+// ── Server ──────────────────────────────────────────────────────────
+
+fn make_router() -> Router<()> {
+    Router::new()
+        .route("shakeBall", shake_ball)
+        .route("readAura", read_aura)
+        .route("consultStars", consult_stars)
+}
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    let router = make_router();
+    let axum = router.into_axum("/");
+
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 8545));
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+
+    println!("Magic 8-Ball RPC listening on http://{}", addr);
+    println!();
+    println!("Try:");
+    println!(r#"  curl -X POST http://localhost:8545 -H 'Content-Type: application/json' \"#);
+    println!(
+        r#"    -d '{{"jsonrpc":"2.0","id":1,"method":"shakeBall","params":"Will I be lucky today?"}}'"#
+    );
+    println!();
+    println!(r#"  curl -X POST http://localhost:8545 -H 'Content-Type: application/json' \"#);
+    println!(r#"    -d '{{"jsonrpc":"2.0","id":2,"method":"readAura","params":"Merlin"}}'"#);
+    println!();
+    println!(r#"  curl -X POST http://localhost:8545 -H 'Content-Type: application/json' \"#);
+    println!(r#"    -d '{{"jsonrpc":"2.0","id":3,"method":"consultStars","params":"gemini"}}'"#);
+
+    axum::serve(listener, axum).await.map_err(Into::into)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ mod tasks;
 pub(crate) use tasks::TaskSet;
 
 mod types;
-pub use types::{ErrorPayload, ResponsePayload};
+pub use types::{ErrorPayload, InternalError, IntoErrorPayload, ResponsePayload};
 
 /// Re-export of the `tower` crate, primarily to provide [`tower::Service`],
 /// and [`tower::service_fn`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,10 @@
 //!
 //! For `Result`-returning handlers, the error type controls the JSON-RPC
 //! error code, message, and optional data via [`IntoErrorPayload`]. Common
-//! error types like `String`, `&str`, `()`, and [`InternalError<T>`] already
-//! implement this trait. The `T` type represents the successful result of the
-//! method, serialized via [`RpcSend::into_raw_value`].
+//! error types like `String`, `&str`, `()`, [`InternalError<T>`], and
+//! [`ErrorPayload<E>`] already implement this trait. The `T` type represents
+//! the successful result of the method, serialized via
+//! [`RpcSend::into_raw_value`].
 //!
 //! See the [`Handler`] trait docs for more information.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!   // Routes get a ctx, which can be used to send notifications.
 //!   .route("notify", |ctx: HandlerCtx| async move {
 //!     if !ctx.notifications_enabled() {
-//!       // This error will appear in the ResponsePayload's `data` field.
+//!       // This error will appear in the ResponsePayload's `message` field.
 //!       return Err("notifications are disabled");
 //!     }
 //!
@@ -56,13 +56,14 @@
 //! when calling methods on the JSON-RPC router.
 //!
 //! Handlers can return either
-//! - `Result<T, E> where T: RpcSend, E: RpcSend`
+//! - `Result<T, E> where T: RpcSend, E: IntoErrorPayload`
 //! - `ResponsePayload<T, E> where T: RpcSend, E: RpcSend`
 //!
-//! These types will be serialized into the JSON-RPC response via
-//! [`RpcSend::into_raw_value`]. The `T` type represents the result of the
-//! method, and the `E` type represents an error response. The `E` type is
-//! optional, and can be set to `()` if no error response is needed.
+//! For `Result`-returning handlers, the error type controls the JSON-RPC
+//! error code, message, and optional data via [`IntoErrorPayload`]. Common
+//! error types like `String`, `&str`, `()`, and [`InternalError<T>`] already
+//! implement this trait. The `T` type represents the successful result of the
+//! method, serialized via [`RpcSend::into_raw_value`].
 //!
 //! See the [`Handler`] trait docs for more information.
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -137,7 +137,8 @@ macro_rules! impl_handler_call {
 
         Box::pin(
             async move {
-                let payload: $crate::ResponsePayload<_, _> = $this().await.into();
+                use $crate::types::IntoResponsePayload as _;
+                let payload = $this().await.into_response_payload();
                 impl_handler_call!(@finish span, id, service, &method, payload);
             }
             .instrument(inst),
@@ -151,7 +152,8 @@ macro_rules! impl_handler_call {
 
         Box::pin(
             async move {
-                let payload: $crate::ResponsePayload<_, _> = $this(ctx).await.into();
+                use $crate::types::IntoResponsePayload as _;
+                let payload = $this(ctx).await.into_response_payload();
                 impl_handler_call!(@finish span, id, service, &method, payload);
             }
             .instrument(inst),
@@ -166,8 +168,9 @@ macro_rules! impl_handler_call {
 
         Box::pin(
             async move {
+                use $crate::types::IntoResponsePayload as _;
                 let params: $params_ty = impl_handler_call!(@unpack_params span, id, service, &method, req);
-                let payload: $crate::ResponsePayload<_, _> = $this(params.into()).await.into();
+                let payload = $this(params.into()).await.into_response_payload();
                 impl_handler_call!(@finish span, id, service, &method, payload);
             }
             .instrument(inst),
@@ -183,7 +186,8 @@ macro_rules! impl_handler_call {
 
         Box::pin(
             async move {
-                let payload: $crate::ResponsePayload<_, _> = $this($state).await.into();
+                use $crate::types::IntoResponsePayload as _;
+                let payload = $this($state).await.into_response_payload();
                 impl_handler_call!(@finish span, id, service, &method, payload);
             }
             .instrument(inst),
@@ -197,8 +201,9 @@ macro_rules! impl_handler_call {
 
         Box::pin(
             async move {
+                use $crate::types::IntoResponsePayload as _;
                 let params: $params_ty = impl_handler_call!(@unpack_params span, id, service, &method, req);
-                let payload: $crate::ResponsePayload<_, _> = $this(ctx, params.into()).await.into();
+                let payload = $this(ctx, params.into()).await.into_response_payload();
                 impl_handler_call!(@finish span, id, service, &method, payload);
             }
             .instrument(inst),
@@ -212,7 +217,8 @@ macro_rules! impl_handler_call {
 
         Box::pin(
             async move {
-                let payload: $crate::ResponsePayload<_, _> = $this(ctx, $state).await.into();
+                use $crate::types::IntoResponsePayload as _;
+                let payload = $this(ctx, $state).await.into_response_payload();
                 impl_handler_call!(@finish span, id, service, &method, payload);
             }
             .instrument(inst),
@@ -226,8 +232,9 @@ macro_rules! impl_handler_call {
 
         Box::pin(
             async move {
+                use $crate::types::IntoResponsePayload as _;
                 let params: $params_ty = impl_handler_call!(@unpack_params span, id, service, &method, req);
-                let payload: $crate::ResponsePayload<_, _> = $this(params.into(), $state).await.into();
+                let payload = $this(params.into(), $state).await.into_response_payload();
                 impl_handler_call!(@finish span, id, service, &method, payload);
             }
             .instrument(inst),
@@ -240,8 +247,9 @@ macro_rules! impl_handler_call {
 
         Box::pin(
             async move {
+                use $crate::types::IntoResponsePayload as _;
                 let params: $params_ty = impl_handler_call!(@unpack_params span, id, service, &method, req);
-                let payload: $crate::ResponsePayload<_, _> = $this(ctx, params.into(), $state).await.into();
+                let payload = $this(ctx, params.into(), $state).await.into_response_payload();
                 impl_handler_call!(@finish span, id, service, &method, payload);
             }
             .instrument(inst),

--- a/src/routes/handler.rs
+++ b/src/routes/handler.rs
@@ -1,5 +1,6 @@
 use crate::{
-    routes::HandlerArgs, types::Response, HandlerCtx, ResponsePayload, Route, RpcRecv, RpcSend,
+    routes::HandlerArgs, types::Response, HandlerCtx, IntoErrorPayload, ResponsePayload, Route,
+    RpcRecv, RpcSend,
 };
 use serde_json::value::RawValue;
 use std::{convert::Infallible, future::Future, marker::PhantomData, pin::Pin, task};
@@ -643,7 +644,7 @@ where
     F: FnOnce() -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = Result<Payload, ErrData>> + Send + 'static,
     Payload: RpcSend,
-    ErrData: RpcSend,
+    ErrData: IntoErrorPayload,
 {
     type Future = Pin<Box<dyn Future<Output = Option<Box<RawValue>>> + Send>>;
 
@@ -657,7 +658,7 @@ where
     F: FnOnce(HandlerCtx) -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = Result<Payload, ErrData>> + Send + 'static,
     Payload: RpcSend,
-    ErrData: RpcSend,
+    ErrData: IntoErrorPayload,
 {
     type Future = Pin<Box<dyn Future<Output = Option<Box<RawValue>>> + Send>>;
 
@@ -672,7 +673,7 @@ where
     Fut: Future<Output = Result<Payload, ErrData>> + Send + 'static,
     Input: RpcRecv,
     Payload: RpcSend,
-    ErrData: RpcSend,
+    ErrData: IntoErrorPayload,
 {
     type Future = Pin<Box<dyn Future<Output = Option<Box<RawValue>>> + Send>>;
 
@@ -687,7 +688,7 @@ where
     Fut: Future<Output = Result<Payload, ErrData>> + Send + 'static,
     Input: RpcRecv,
     Payload: RpcSend,
-    ErrData: RpcSend,
+    ErrData: IntoErrorPayload,
 {
     type Future = Pin<Box<dyn Future<Output = Option<Box<RawValue>>> + Send>>;
 
@@ -701,7 +702,7 @@ where
     F: FnOnce(S) -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = Result<Payload, ErrData>> + Send + 'static,
     Payload: RpcSend,
-    ErrData: RpcSend,
+    ErrData: IntoErrorPayload,
     S: Send + Sync + 'static,
 {
     type Future = Pin<Box<dyn Future<Output = Option<Box<RawValue>>> + Send>>;
@@ -716,7 +717,7 @@ where
     F: FnOnce(State<S>) -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = Result<Payload, ErrData>> + Send + 'static,
     Payload: RpcSend,
-    ErrData: RpcSend,
+    ErrData: IntoErrorPayload,
     S: Send + Sync + 'static,
 {
     type Future = Pin<Box<dyn Future<Output = Option<Box<RawValue>>> + Send>>;
@@ -733,7 +734,7 @@ where
     Fut: Future<Output = Result<Payload, ErrData>> + Send + 'static,
     Input: RpcRecv,
     Payload: RpcSend,
-    ErrData: RpcSend,
+    ErrData: IntoErrorPayload,
 {
     type Future = Pin<Box<dyn Future<Output = Option<Box<RawValue>>> + Send>>;
 
@@ -748,7 +749,7 @@ where
     Fut: Future<Output = Result<Payload, ErrData>> + Send + 'static,
     Input: RpcRecv,
     Payload: RpcSend,
-    ErrData: RpcSend,
+    ErrData: IntoErrorPayload,
 {
     type Future = Pin<Box<dyn Future<Output = Option<Box<RawValue>>> + Send>>;
 
@@ -763,7 +764,7 @@ where
     Fut: Future<Output = Result<Payload, ErrData>> + Send + 'static,
     Input: RpcRecv,
     Payload: RpcSend,
-    ErrData: RpcSend,
+    ErrData: IntoErrorPayload,
     S: Send + Sync + 'static,
 {
     type Future = Pin<Box<dyn Future<Output = Option<Box<RawValue>>> + Send>>;
@@ -778,7 +779,7 @@ where
     F: FnOnce(HandlerCtx, S) -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = Result<Payload, ErrData>> + Send + 'static,
     Payload: RpcSend,
-    ErrData: RpcSend,
+    ErrData: IntoErrorPayload,
     S: Send + Sync + 'static,
 {
     type Future = Pin<Box<dyn Future<Output = Option<Box<RawValue>>> + Send>>;
@@ -793,7 +794,7 @@ where
     F: FnOnce(HandlerCtx, State<S>) -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = Result<Payload, ErrData>> + Send + 'static,
     Payload: RpcSend,
-    ErrData: RpcSend,
+    ErrData: IntoErrorPayload,
     S: Send + Sync + 'static,
 {
     type Future = Pin<Box<dyn Future<Output = Option<Box<RawValue>>> + Send>>;
@@ -809,7 +810,7 @@ where
     Fut: Future<Output = Result<Payload, ErrData>> + Send + 'static,
     Input: RpcRecv,
     Payload: RpcSend,
-    ErrData: RpcSend,
+    ErrData: IntoErrorPayload,
     S: Send + Sync + 'static,
 {
     type Future = Pin<Box<dyn Future<Output = Option<Box<RawValue>>> + Send>>;

--- a/src/routes/handler.rs
+++ b/src/routes/handler.rs
@@ -39,19 +39,50 @@ pub struct PhantomParams<T>(PhantomData<T>);
 ///
 /// ### Returning error messages
 ///
-/// Note that when a [`Handler`] returns a `Result`, the error type will be in
-/// the [`ResponsePayload`]'s `data` field, and the message and code will
-/// indicate an internal server error. To return a response with an error code
-/// and custom `message` field, use a handler that returns an instance of the
-/// [`ResponsePayload`] enum, and instantiate that error payload manually.
+/// When a [`Handler`] returns a `Result`, the error type must implement
+/// [`IntoErrorPayload`]. This trait controls the JSON-RPC error code,
+/// message, and optional structured data in the response.
+///
+/// Several common types already implement [`IntoErrorPayload`]:
+///
+/// - **`String` / `&str`** -- produces code `-32603` with the string as
+///   the `message` field.
+/// - **`()`** -- produces code `-32603` with the default `"Internal error"`
+///   message.
+/// - **[`InternalError<T>`]** -- produces code `-32603` with `T` as the
+///   `data` field. Has a blanket [`From<T>`] impl, so it works with the
+///   `?` operator to reproduce the old `E: RpcSend` behavior.
+/// - **[`ErrorPayload<E>`]** -- passed through as-is.
 ///
 /// ```
-/// # use ajj::ResponsePayload;
-/// let handler_a = || async { Err::<(), _>("appears in \"data\"") };
-/// let handler_b = || async {
+/// # use ajj::{IntoErrorPayload, InternalError, ErrorPayload, ResponsePayload};
+/// # use std::borrow::Cow;
+/// // String errors: the string appears in the `message` field.
+/// let handler_a = || async { Err::<(), _>("something went wrong") };
+///
+/// // Custom IntoErrorPayload impl for full control.
+/// # #[derive(Debug, Clone)]
+/// # struct MyError;
+/// # impl IntoErrorPayload for MyError {
+/// #     type ErrData = ();
+/// #     fn error_code(&self) -> i64 { 42 }
+/// #     fn error_message(&self) -> Cow<'static, str> { "my error".into() }
+/// # }
+/// let handler_b = || async { Err::<(), MyError>(MyError) };
+///
+/// // InternalError<T> wraps any RpcSend value as `-32603` error data,
+/// // matching the old `E: RpcSend` behavior.
+/// let handler_c = || async { Err::<(), InternalError<u32>>(InternalError(42)) };
+///
+/// // Or return a ResponsePayload directly for complete control.
+/// let handler_d = || async {
 ///     ResponsePayload::<(), ()>::internal_error_message("appears in \"message\"".into())
 /// };
 /// ```
+///
+/// [`IntoErrorPayload`]: crate::IntoErrorPayload
+/// [`InternalError<T>`]: crate::InternalError
+/// [`ErrorPayload<E>`]: crate::ErrorPayload
 ///
 /// ### The [`HandlerCtx`]: tasks and notifications.
 ///
@@ -262,8 +293,9 @@ pub struct PhantomParams<T>(PhantomData<T>);
 /// ## Blanket Implementations
 ///
 /// This trait is blanket implemented for the following function and closure
-/// types, where `Fut` is a [`Future`] returning either [`ResponsePayload`] or
-/// [`Result`]:
+/// types, where `Fut` is a [`Future`] returning either
+/// `ResponsePayload<T: RpcSend, E: RpcSend>` or
+/// `Result<T: RpcSend, E: IntoErrorPayload>`:
 ///
 /// - `async fn()`
 /// - `async fn(HandlerCtx) -> Fut`

--- a/src/routes/handler.rs
+++ b/src/routes/handler.rs
@@ -50,8 +50,7 @@ pub struct PhantomParams<T>(PhantomData<T>);
 /// - **`()`** -- produces code `-32603` with the default `"Internal error"`
 ///   message.
 /// - **[`InternalError<T>`]** -- produces code `-32603` with `T` as the
-///   `data` field. Has a blanket [`From<T>`] impl, so it works with the
-///   `?` operator to reproduce the old `E: RpcSend` behavior.
+///   `data` field.
 /// - **[`ErrorPayload<E>`]** -- passed through as-is.
 ///
 /// ```
@@ -70,8 +69,7 @@ pub struct PhantomParams<T>(PhantomData<T>);
 /// # }
 /// let handler_b = || async { Err::<(), MyError>(MyError) };
 ///
-/// // InternalError<T> wraps any RpcSend value as `-32603` error data,
-/// // matching the old `E: RpcSend` behavior.
+/// // InternalError<T> wraps any RpcSend value as `-32603` error data.
 /// let handler_c = || async { Err::<(), InternalError<u32>>(InternalError(42)) };
 ///
 /// // Or return a ResponsePayload directly for complete control.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use req::Request;
 
 mod resp;
 pub(crate) use resp::Response;
-pub use resp::{ErrorPayload, ResponsePayload};
+pub use resp::{ErrorPayload, InternalError, IntoErrorPayload, ResponsePayload};
 
 mod error;
 pub(crate) use error::RequestError;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,8 +10,8 @@ mod req;
 pub(crate) use req::Request;
 
 mod resp;
-pub(crate) use resp::Response;
 pub use resp::{ErrorPayload, InternalError, IntoErrorPayload, ResponsePayload};
+pub(crate) use resp::{IntoResponsePayload, Response};
 
 mod error;
 pub(crate) use error::RequestError;

--- a/src/types/resp/into_error.rs
+++ b/src/types/resp/into_error.rs
@@ -121,10 +121,6 @@ pub trait IntoErrorPayload {
 /// A wrapper that maps any `T: RpcSend` into a JSON-RPC "Internal error"
 /// (`-32603`) with `T` as the error data.
 ///
-/// `InternalError` implements [`From<T>`] for ergonomic use with the `?`
-/// operator: any error type can be converted into an `InternalError`
-/// automatically.
-///
 /// # Example
 ///
 /// ```
@@ -138,12 +134,6 @@ pub trait IntoErrorPayload {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InternalError<T>(pub T);
-
-impl<T> From<T> for InternalError<T> {
-    fn from(value: T) -> Self {
-        Self(value)
-    }
-}
 
 impl<T: RpcSend> IntoErrorPayload for InternalError<T> {
     type ErrData = T;
@@ -239,12 +229,6 @@ mod tests {
         assert_eq!(payload.code, -32603);
         assert_eq!(payload.message, "Internal error");
         assert_eq!(payload.data, Some(42u64));
-    }
-
-    #[test]
-    fn internal_error_from() {
-        let err: InternalError<u64> = 42u64.into();
-        assert_eq!(err.0, 42u64);
     }
 
     #[test]

--- a/src/types/resp/into_error.rs
+++ b/src/types/resp/into_error.rs
@@ -1,0 +1,360 @@
+use crate::{ErrorPayload, RpcSend};
+use std::borrow::Cow;
+
+/// A trait for converting an error type into a JSON-RPC 2.0
+/// [`ErrorPayload`].
+///
+/// By default, handler errors in `ajj` are mapped to JSON-RPC error code
+/// `-32603` ("Internal error"). Implement this trait on your error types to
+/// control the error code, message, and optional structured data that
+/// appear in the response.
+///
+/// # Provided methods
+///
+/// Only [`error_code`] is required. The remaining methods have sensible
+/// defaults:
+///
+/// | Method               | Default                                |
+/// |----------------------|----------------------------------------|
+/// | [`error_message`]    | `"Internal error"`                     |
+/// | [`error_data`]       | `None`                                 |
+/// | [`into_error_payload`] | Assembles from the other three methods |
+///
+/// Override [`into_error_payload`] when you can produce the
+/// [`ErrorPayload`] more efficiently than calling each accessor
+/// individually.
+///
+/// # Example
+///
+/// ```
+/// use ajj::{IntoErrorPayload, ErrorPayload};
+/// use std::borrow::Cow;
+///
+/// #[derive(Debug)]
+/// enum AppError {
+///     NotFound(String),
+///     RateLimited { retry_after: u64 },
+/// }
+///
+/// impl IntoErrorPayload for AppError {
+///     type ErrData = String;
+///
+///     fn error_code(&self) -> i64 {
+///         match self {
+///             Self::NotFound(_) => 404,
+///             Self::RateLimited { .. } => 429,
+///         }
+///     }
+///
+///     fn error_message(&self) -> Cow<'static, str> {
+///         match self {
+///             Self::NotFound(_) => "Not found".into(),
+///             Self::RateLimited { .. } => "Rate limited".into(),
+///         }
+///     }
+///
+///     fn error_data(self) -> Option<String> {
+///         match self {
+///             Self::NotFound(resource) => Some(resource),
+///             Self::RateLimited { retry_after } => {
+///                 Some(format!("retry after {retry_after}s"))
+///             }
+///         }
+///     }
+/// }
+///
+/// let err = AppError::NotFound("user/42".into());
+/// let payload = err.into_error_payload();
+/// assert_eq!(payload.code, 404);
+/// assert_eq!(payload.message, "Not found");
+/// assert_eq!(payload.data.as_deref(), Some("user/42"));
+/// ```
+///
+/// [`error_code`]: IntoErrorPayload::error_code
+/// [`error_message`]: IntoErrorPayload::error_message
+/// [`error_data`]: IntoErrorPayload::error_data
+/// [`into_error_payload`]: IntoErrorPayload::into_error_payload
+pub trait IntoErrorPayload {
+    /// The type of structured data included in the error response.
+    type ErrData: RpcSend;
+
+    /// The JSON-RPC error code.
+    fn error_code(&self) -> i64;
+
+    /// A short human-readable description of the error.
+    ///
+    /// Defaults to `"Internal error"`.
+    fn error_message(&self) -> Cow<'static, str> {
+        Cow::Borrowed("Internal error")
+    }
+
+    /// Optional structured data to include in the error response.
+    ///
+    /// Defaults to `None`.
+    fn error_data(self) -> Option<Self::ErrData>
+    where
+        Self: Sized,
+    {
+        None
+    }
+
+    /// Consume this value and produce an [`ErrorPayload`].
+    ///
+    /// The default implementation calls [`error_code`], [`error_message`],
+    /// and [`error_data`].
+    ///
+    /// [`error_code`]: IntoErrorPayload::error_code
+    /// [`error_message`]: IntoErrorPayload::error_message
+    /// [`error_data`]: IntoErrorPayload::error_data
+    fn into_error_payload(self) -> ErrorPayload<Self::ErrData>
+    where
+        Self: Sized,
+    {
+        ErrorPayload {
+            code: self.error_code(),
+            message: self.error_message(),
+            data: self.error_data(),
+        }
+    }
+}
+
+/// A wrapper that maps any `T: RpcSend` into a JSON-RPC "Internal error"
+/// (`-32603`) with `T` as the error data.
+///
+/// `InternalError` implements [`From<T>`] for ergonomic use with the `?`
+/// operator: any error type can be converted into an `InternalError`
+/// automatically.
+///
+/// # Example
+///
+/// ```
+/// use ajj::{InternalError, IntoErrorPayload};
+///
+/// let err = InternalError("something went wrong");
+/// let payload = err.into_error_payload();
+/// assert_eq!(payload.code, -32603);
+/// assert_eq!(payload.message, "Internal error");
+/// assert_eq!(payload.data, Some("something went wrong"));
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InternalError<T>(pub T);
+
+impl<T> From<T> for InternalError<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T: RpcSend> IntoErrorPayload for InternalError<T> {
+    type ErrData = T;
+
+    fn error_code(&self) -> i64 {
+        -32603
+    }
+
+    fn error_data(self) -> Option<T> {
+        Some(self.0)
+    }
+}
+
+impl<E: RpcSend> IntoErrorPayload for ErrorPayload<E> {
+    type ErrData = E;
+
+    fn error_code(&self) -> i64 {
+        self.code
+    }
+
+    fn error_message(&self) -> Cow<'static, str> {
+        self.message.clone()
+    }
+
+    fn error_data(self) -> Option<E> {
+        self.data
+    }
+
+    fn into_error_payload(self) -> ErrorPayload<E> {
+        self
+    }
+}
+
+impl IntoErrorPayload for String {
+    type ErrData = ();
+
+    fn error_code(&self) -> i64 {
+        -32603
+    }
+
+    fn error_message(&self) -> Cow<'static, str> {
+        Cow::Owned(self.clone())
+    }
+
+    fn into_error_payload(self) -> ErrorPayload<()> {
+        ErrorPayload {
+            code: -32603,
+            message: Cow::Owned(self),
+            data: None,
+        }
+    }
+}
+
+impl IntoErrorPayload for &'static str {
+    type ErrData = ();
+
+    fn error_code(&self) -> i64 {
+        -32603
+    }
+
+    fn error_message(&self) -> Cow<'static, str> {
+        Cow::Borrowed(self)
+    }
+
+    fn into_error_payload(self) -> ErrorPayload<()> {
+        ErrorPayload {
+            code: -32603,
+            message: Cow::Borrowed(self),
+            data: None,
+        }
+    }
+}
+
+impl IntoErrorPayload for () {
+    type ErrData = ();
+
+    fn error_code(&self) -> i64 {
+        -32603
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn internal_error_wrapper() {
+        let err = InternalError(42u64);
+        assert_eq!(err.error_code(), -32603);
+        assert_eq!(err.error_message(), "Internal error");
+
+        let payload = err.into_error_payload();
+        assert_eq!(payload.code, -32603);
+        assert_eq!(payload.message, "Internal error");
+        assert_eq!(payload.data, Some(42u64));
+    }
+
+    #[test]
+    fn internal_error_from() {
+        let err: InternalError<u64> = 42u64.into();
+        assert_eq!(err.0, 42u64);
+    }
+
+    #[test]
+    fn error_payload_identity() {
+        let original = ErrorPayload {
+            code: 404,
+            message: Cow::Borrowed("Not found"),
+            data: Some("missing".to_string()),
+        };
+        assert_eq!(original.error_code(), 404);
+        assert_eq!(original.error_message(), "Not found");
+
+        let payload = original.into_error_payload();
+        assert_eq!(payload.code, 404);
+        assert_eq!(payload.message, "Not found");
+        assert_eq!(payload.data.as_deref(), Some("missing"));
+    }
+
+    #[test]
+    fn error_payload_no_data() {
+        let original: ErrorPayload<()> = ErrorPayload {
+            code: -32603,
+            message: Cow::Borrowed("Internal error"),
+            data: None,
+        };
+        let payload = original.into_error_payload();
+        assert_eq!(payload.code, -32603);
+        assert_eq!(payload.data, None);
+    }
+
+    #[test]
+    fn string_error() {
+        let err = "bad input".to_string();
+        assert_eq!(err.error_code(), -32603);
+        assert_eq!(err.error_message(), "bad input");
+
+        let err2 = "bad input".to_string();
+        let payload = err2.into_error_payload();
+        assert_eq!(payload.code, -32603);
+        assert_eq!(payload.message, "bad input");
+        assert_eq!(payload.data, None);
+    }
+
+    #[test]
+    fn static_str_error() {
+        let err: &'static str = "oops";
+        assert_eq!(err.error_code(), -32603);
+        assert_eq!(err.error_message(), "oops");
+
+        let payload = err.into_error_payload();
+        assert_eq!(payload.code, -32603);
+        assert_eq!(payload.message, "oops");
+        assert_eq!(payload.data, None);
+    }
+
+    #[test]
+    fn unit_error() {
+        let err = ();
+        assert_eq!(err.error_code(), -32603);
+        assert_eq!(err.error_message(), "Internal error");
+
+        let payload = err.into_error_payload();
+        assert_eq!(payload.code, -32603);
+        assert_eq!(payload.message, "Internal error");
+        assert_eq!(payload.data, None);
+    }
+
+    #[test]
+    fn custom_error_type() {
+        #[derive(Debug)]
+        enum AppError {
+            NotFound(String),
+            Internal,
+        }
+
+        impl IntoErrorPayload for AppError {
+            type ErrData = String;
+
+            fn error_code(&self) -> i64 {
+                match self {
+                    Self::NotFound(_) => 404,
+                    Self::Internal => -32603,
+                }
+            }
+
+            fn error_message(&self) -> Cow<'static, str> {
+                match self {
+                    Self::NotFound(_) => "Not found".into(),
+                    Self::Internal => "Internal error".into(),
+                }
+            }
+
+            fn error_data(self) -> Option<String> {
+                match self {
+                    Self::NotFound(resource) => Some(resource),
+                    Self::Internal => None,
+                }
+            }
+        }
+
+        let err = AppError::NotFound("user/42".into());
+        let payload = err.into_error_payload();
+        assert_eq!(payload.code, 404);
+        assert_eq!(payload.message, "Not found");
+        assert_eq!(payload.data.as_deref(), Some("user/42"));
+
+        let err = AppError::Internal;
+        let payload = err.into_error_payload();
+        assert_eq!(payload.code, -32603);
+        assert_eq!(payload.message, "Internal error");
+        assert_eq!(payload.data, None);
+    }
+}

--- a/src/types/resp/into_response.rs
+++ b/src/types/resp/into_response.rs
@@ -1,0 +1,62 @@
+use crate::{types::resp::IntoErrorPayload, ResponsePayload, RpcSend};
+
+/// Internal trait unifying `Result<T, E>` and `ResponsePayload<T, E>`
+/// conversion in the handler macro.
+pub(crate) trait IntoResponsePayload {
+    /// The successful payload type.
+    type Payload: RpcSend;
+    /// The error data type.
+    type ErrData: RpcSend;
+
+    /// Convert this value into a [`ResponsePayload`].
+    fn into_response_payload(self) -> ResponsePayload<Self::Payload, Self::ErrData>;
+}
+
+impl<T: RpcSend, E: RpcSend> IntoResponsePayload for ResponsePayload<T, E> {
+    type Payload = T;
+    type ErrData = E;
+
+    fn into_response_payload(self) -> ResponsePayload<T, E> {
+        self
+    }
+}
+
+impl<T: RpcSend, E: IntoErrorPayload> IntoResponsePayload for Result<T, E> {
+    type Payload = T;
+    type ErrData = E::ErrData;
+
+    fn into_response_payload(self) -> ResponsePayload<T, E::ErrData> {
+        match self {
+            Ok(ok) => ResponsePayload(Ok(ok)),
+            Err(err) => ResponsePayload(Err(err.into_error_payload())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_payload_identity() {
+        let rp = ResponsePayload::<u32, ()>(Ok(42));
+        let result = rp.into_response_payload();
+        assert_eq!(result.as_success(), Some(&42));
+    }
+
+    #[test]
+    fn result_ok_converts() {
+        let r: Result<u32, &str> = Ok(42);
+        let rp = r.into_response_payload();
+        assert_eq!(rp.as_success(), Some(&42));
+    }
+
+    #[test]
+    fn result_err_uses_into_error_payload() {
+        let r: Result<u32, &str> = Err("bad");
+        let rp = r.into_response_payload();
+        let err = rp.as_error().unwrap();
+        assert_eq!(err.code, -32603);
+        assert_eq!(err.message, "bad");
+    }
+}

--- a/src/types/resp/mod.rs
+++ b/src/types/resp/mod.rs
@@ -1,5 +1,7 @@
 mod into_error;
 pub use into_error::{InternalError, IntoErrorPayload};
+mod into_response;
+pub(crate) use into_response::IntoResponsePayload;
 
 mod payload;
 pub use payload::{ErrorPayload, ResponsePayload};

--- a/src/types/resp/mod.rs
+++ b/src/types/resp/mod.rs
@@ -1,3 +1,6 @@
+mod into_error;
+pub use into_error::{InternalError, IntoErrorPayload};
+
 mod payload;
 pub use payload::{ErrorPayload, ResponsePayload};
 

--- a/src/types/resp/payload.rs
+++ b/src/types/resp/payload.rs
@@ -14,18 +14,6 @@ const INTERNAL_ERROR: Cow<'_, str> = Cow::Borrowed("Internal error");
 #[repr(transparent)]
 pub struct ResponsePayload<Payload, ErrData>(pub Result<Payload, ErrorPayload<ErrData>>);
 
-impl<T, E> From<Result<T, E>> for ResponsePayload<T, E>
-where
-    E: RpcSend,
-{
-    fn from(res: Result<T, E>) -> Self {
-        match res {
-            Ok(payload) => Self(Ok(payload)),
-            Err(err) => Self(Err(ErrorPayload::internal_error_with_obj(err))),
-        }
-    }
-}
-
 impl<Payload, ErrData> ResponsePayload<Payload, ErrData> {
     /// Create a new error payload for a parse error.
     pub const fn parse_error() -> Self {
@@ -104,18 +92,6 @@ impl<Payload, ErrData> ResponsePayload<Payload, ErrData> {
     /// Returns `true` if the response payload is an error.
     pub const fn is_error(&self) -> bool {
         matches!(self, Self(Err(_)))
-    }
-
-    /// Convert a result into a response payload, by converting the error into
-    /// an internal error message.
-    pub fn convert_internal_error_msg<T>(res: Result<Payload, T>) -> Self
-    where
-        T: Into<Cow<'static, str>>,
-    {
-        match res {
-            Ok(payload) => Self(Ok(payload)),
-            Err(err) => Self(Err(ErrorPayload::internal_error_message(err.into()))),
-        }
     }
 }
 
@@ -212,19 +188,6 @@ impl<E> ErrorPayload<E> {
             code: -32603,
             message,
             data: Some(data),
-        }
-    }
-}
-
-impl<T> From<T> for ErrorPayload<T>
-where
-    T: std::error::Error + RpcSend,
-{
-    fn from(value: T) -> Self {
-        Self {
-            code: -32603,
-            message: INTERNAL_ERROR,
-            data: Some(value),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `IntoErrorPayload` trait that lets handler error types control JSON-RPC error code, message, and data fields when returning `Result<T, E>`
- Adds `InternalError<T>` wrapper for placing a value in the error `data` field with code `-32603`
- Adds convenience impls for `ErrorPayload`, `String`, `&'static str`, `()`
- Adds internal `IntoResponsePayload` trait to unify the macro conversion path
- Removes `From<Result<T, E>> for ResponsePayload`, `From<T> for ErrorPayload<T> where T: Error + RpcSend`, and `convert_internal_error_msg`
- Adds `magic8ball` example showcasing custom error types with per-variant error codes and structured data
- Bumps version to 0.7.0

## Breaking changes

- `Result<T, E>` handlers now require `E: IntoErrorPayload` instead of `E: RpcSend`
- `String`/`&str` errors now populate the `message` field (previously went in `data`)
- Removed `From<Result<T, E>> for ResponsePayload`, `From<T> for ErrorPayload<T> where T: Error + RpcSend`, and `ResponsePayload::convert_internal_error_msg`
- Migration: wrap error types in `InternalError<E>` for the old behavior, or implement `IntoErrorPayload` for custom error codes

## Test plan

- [x] Unit tests for all `IntoErrorPayload` impls (ErrorPayload identity, InternalError, String, &str, (), custom error type)
- [x] Unit tests for `IntoResponsePayload` (Result and ResponsePayload paths)
- [x] Existing handler inference tests pass
- [x] All doc tests compile and pass
- [x] Integration tests (ws, ipc, axum) pass
- [x] Clippy clean with `--all-features` and `--no-default-features`
- [x] magic8ball example compiles and demonstrates all error paths

Closes ENG-2085

🤖 Generated with [Claude Code](https://claude.com/claude-code)