### PR TITLE
fix: address review nits from #42

### DIFF
--- a/examples/magic8ball.rs
+++ b/examples/magic8ball.rs
@@ -81,10 +81,10 @@ impl IntoErrorPayload for MysticError {
 
     fn error_code(&self) -> i64 {
         match self {
-            Self::CrystalBallCloudy => -32001,
-            Self::StarsMisaligned { .. } => -32002,
-            Self::MercuryRetrograde => -32003,
-            Self::UnreadableAura(_) => -32004,
+            Self::CrystalBallCloudy => 2001,
+            Self::StarsMisaligned { .. } => 2002,
+            Self::MercuryRetrograde => 2003,
+            Self::UnreadableAura(_) => 2004,
         }
     }
 
@@ -100,7 +100,7 @@ impl IntoErrorPayload for MysticError {
     fn into_error_payload(self) -> ErrorPayload<Box<serde_json::value::RawValue>> {
         let code = self.error_code();
         let message = self.error_message();
-        let data = match &self {
+        let data = match self {
             Self::CrystalBallCloudy => serde_json::value::to_raw_value(&CloudyDetail {
                 visibility: "opaque",
                 suggestion: "try polishing the ball",
@@ -108,7 +108,7 @@ impl IntoErrorPayload for MysticError {
             .ok(),
             Self::StarsMisaligned { sign } => {
                 serde_json::value::to_raw_value(&MisalignmentDetail {
-                    sign: sign.clone(),
+                    sign,
                     interfering_planet: "Saturn",
                 })
                 .ok()

--- a/src/types/resp/into_error.rs
+++ b/src/types/resp/into_error.rs
@@ -11,8 +11,8 @@ use std::borrow::Cow;
 ///
 /// # Provided methods
 ///
-/// Only [`error_code`] is required. The remaining methods have sensible
-/// defaults:
+/// Only [`error_code`] and the associated type `ErrData` must be specified.
+/// The remaining methods have sensible defaults:
 ///
 /// | Method               | Default                                |
 /// |----------------------|----------------------------------------|
@@ -41,8 +41,8 @@ use std::borrow::Cow;
 ///
 ///     fn error_code(&self) -> i64 {
 ///         match self {
-///             Self::NotFound(_) => 404,
-///             Self::RateLimited { .. } => 429,
+///             Self::NotFound(_) => 1001,
+///             Self::RateLimited { .. } => 1002,
 ///         }
 ///     }
 ///
@@ -65,7 +65,7 @@ use std::borrow::Cow;
 ///
 /// let err = AppError::NotFound("user/42".into());
 /// let payload = err.into_error_payload();
-/// assert_eq!(payload.code, 404);
+/// assert_eq!(payload.code, 1001);
 /// assert_eq!(payload.message, "Not found");
 /// assert_eq!(payload.data.as_deref(), Some("user/42"));
 /// ```
@@ -215,6 +215,14 @@ impl IntoErrorPayload for () {
     }
 }
 
+impl IntoErrorPayload for core::convert::Infallible {
+    type ErrData = ();
+
+    fn error_code(&self) -> i64 {
+        match *self {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,15 +242,15 @@ mod tests {
     #[test]
     fn error_payload_identity() {
         let original = ErrorPayload {
-            code: 404,
+            code: 1001,
             message: Cow::Borrowed("Not found"),
             data: Some("missing".to_string()),
         };
-        assert_eq!(original.error_code(), 404);
+        assert_eq!(original.error_code(), 1001);
         assert_eq!(original.error_message(), "Not found");
 
         let payload = original.into_error_payload();
-        assert_eq!(payload.code, 404);
+        assert_eq!(payload.code, 1001);
         assert_eq!(payload.message, "Not found");
         assert_eq!(payload.data.as_deref(), Some("missing"));
     }
@@ -309,7 +317,7 @@ mod tests {
 
             fn error_code(&self) -> i64 {
                 match self {
-                    Self::NotFound(_) => 404,
+                    Self::NotFound(_) => 1001,
                     Self::Internal => -32603,
                 }
             }
@@ -331,7 +339,7 @@ mod tests {
 
         let err = AppError::NotFound("user/42".into());
         let payload = err.into_error_payload();
-        assert_eq!(payload.code, 404);
+        assert_eq!(payload.code, 1001);
         assert_eq!(payload.message, "Not found");
         assert_eq!(payload.data.as_deref(), Some("user/42"));
 


### PR DESCRIPTION
## Summary

- Use application-level error codes (1001+, 2001+) instead of reserved JSON-RPC range `[-32099, -32000]` in examples and doc tests
- Fix doc example error codes that looked like HTTP status codes (404, 429)
- Add `impl IntoErrorPayload for core::convert::Infallible`
- Clarify in trait docs that `ErrData` associated type must also be specified
- Refactor magic8ball `into_error_payload` match to take `self` by value, removing unnecessary `.clone()`

Addresses non-blocking nits from @0xfmac on #42.

## Test plan

- [x] `cargo t -p ajj` — all 25 unit + 20 doc-tests pass
- [x] `cargo clippy --all-features --all-targets` clean
- [x] `cargo clippy --no-default-features --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)