### PR TITLE
chore: downgrade per-message log to trace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-*: @Evalir @prestwich @dylanlott
-.github/: @rswanson
+* @init4tech/engineering
+.github @init4tech/devops

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "Simple, modern, ergonomic JSON-RPC 2.0 router built with tower an
 keywords = ["json-rpc", "jsonrpc", "json"]
 categories = ["web-programming::http-server", "web-programming::websocket"]
 
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.81"
 authors = ["init4", "James Prestwich"]

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -95,6 +95,7 @@ where
             let req = ctx.span().in_scope(|| {
                 message_event!(
                     @received,
+                    service: self.router.service_name(),
                     counter: &self.rx_msg_id,
                     bytes: bytes.len(),
                 );
@@ -122,6 +123,7 @@ where
                 span.in_scope(|| {
                     message_event!(
                         @sent,
+                        service: self.router.service_name(),
                         counter: &self.tx_msg_id,
                         bytes: body.len(),
                     );

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -54,25 +54,31 @@ macro_rules! unwrap_infallible {
     };
 }
 
-/// Log a message event to the current span.
+/// Log a message event to the current span, and record its uncompressed size in the
+/// `ajj.router.message_size_bytes` histogram.
+///
+/// Per-message logs are emitted at `trace` level to avoid flooding production logs; operators
+/// should rely on the histogram metric for size visibility.
 ///
 /// See <https://github.com/open-telemetry/semantic-conventions/blob/d66109ff41e75f49587114e5bff9d101b87f40bd/docs/rpc/rpc-spans.md#events>
 macro_rules! message_event {
-    ($type:literal, counter: $counter:expr, bytes: $bytes:expr,) => {{
-        ::tracing::info!(
+    ($type:literal, service: $service:expr, counter: $counter:expr, bytes: $bytes:expr,) => {{
+        let bytes = $bytes;
+        ::tracing::trace!(
             "rpc.message.id" = $counter.fetch_add(1, ::std::sync::atomic::Ordering::Relaxed),
             "rpc.message.type" = $type,
-            "rpc.message.uncompressed_size" = $bytes,
+            "rpc.message.uncompressed_size" = bytes,
             "rpc.message"
         );
+        $crate::metrics::record_message_size($service, $type, bytes);
     }};
 
-    (@received, counter: $counter:expr, bytes: $bytes:expr, ) => {
-        message_event!("RECEIVED", counter: $counter, bytes: $bytes,);
+    (@received, service: $service:expr, counter: $counter:expr, bytes: $bytes:expr, ) => {
+        message_event!("RECEIVED", service: $service, counter: $counter, bytes: $bytes,);
     };
 
-    (@sent, counter: $counter:expr, bytes: $bytes:expr, ) => {
-        message_event!("SENT", counter: $counter, bytes: $bytes,);
+    (@sent, service: $service:expr, counter: $counter:expr, bytes: $bytes:expr, ) => {
+        message_event!("SENT", service: $service, counter: $counter, bytes: $bytes,);
     };
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4,51 +4,51 @@ use std::sync::LazyLock;
 /// Metric name for counting router calls.
 pub(crate) const ROUTER_CALLS: &str = "ajj.router.calls";
 pub(crate) const ROUTER_CALLS_HELP: &str =
-    "Number of calls to ajj router methods. Not all requests will result in a response.";
+    "Number of calls to ajj router methods (not all requests will result in a response)";
 
 /// Metric name for counting router error execution.
 pub(crate) const ROUTER_ERRORS: &str = "ajj.router.errors";
 pub(crate) const ROUTER_ERRORS_HELP: &str =
-    "Number of errored executions by ajj router methods. This does NOT imply a response was sent.";
+    "Number of errored executions by ajj router methods (this does NOT imply a response was sent)";
 
-// Metric name for counting router successful executions.
+/// Metric name for counting router successful executions.
 pub(crate) const ROUTER_SUCCESSES: &str = "ajj.router.successes";
 pub(crate) const ROUTER_SUCCESSES_HELP: &str =
-    "Number of successful executions by ajj router methods. This does NOT imply a response was sent.";
+    "Number of successful executions by ajj router methods (this does NOT imply a response was sent)";
 
 /// Metric name for counting router responses.
 pub(crate) const ROUTER_RESPONSES: &str = "ajj.router.responses";
 pub(crate) const ROUTER_RESPONSES_HELP: &str =
-    "Number of responses sent by ajj router methods. Not all requests will result in a response.";
+    "Number of responses sent by ajj router methods (not all requests will result in a response)";
 
-// Metric name for counting omitted notification responses.
+/// Metric name for counting omitted notification responses.
 pub(crate) const ROUTER_NOTIFICATION_RESPONSE_OMITTED: &str =
     "ajj.router.notification_response_omitted";
 pub(crate) const ROUTER_NOTIFICATION_RESPONSE_OMITTED_HELP: &str =
     "Number of times ajj router methods omitted a response to a notification";
 
-// Metric for counting parse errors.
+/// Metric for counting parse errors.
 pub(crate) const ROUTER_PARSE_ERRORS: &str = "ajj.router.parse_errors";
 pub(crate) const ROUTER_PARSE_ERRORS_HELP: &str =
-    "Number of parse errors encountered by ajj router methods. This implies no response was sent.";
+    "Number of parse errors encountered by ajj router methods (this implies no response was sent)";
 
 /// Metric for counting method not found errors.
 pub(crate) const ROUTER_METHOD_NOT_FOUND: &str = "ajj.router.method_not_found";
 pub(crate) const ROUTER_METHOD_NOT_FOUND_HELP: &str =
-    "Number of times ajj router methods encountered a method not found error. This implies a response was sent.";
+    "Number of times ajj router methods encountered a method not found error (this implies a response was sent)";
 
 /// Metric for tracking active calls.
 pub(crate) const ACTIVE_CALLS: &str = "ajj.router.active_calls";
 pub(crate) const ACTIVE_CALLS_HELP: &str = "Number of active calls being processed";
 
-/// Metric for tracking completed   calls.
+/// Metric for tracking completed calls.
 pub(crate) const COMPLETED_CALLS: &str = "ajj.router.completed_calls";
 pub(crate) const COMPLETED_CALLS_HELP: &str = "Number of completed calls handled";
 
 /// Metric for the uncompressed size in bytes of messages received from and sent to clients.
 pub(crate) const ROUTER_MESSAGE_SIZE: &str = "ajj.router.message_size_bytes";
 pub(crate) const ROUTER_MESSAGE_SIZE_HELP: &str =
-    "Uncompressed size in bytes of JSON-RPC messages received from and sent to clients.";
+    "Uncompressed size in bytes of JSON-RPC messages received from and sent to clients";
 
 static DESCRIBE: LazyLock<()> = LazyLock::new(|| {
     metrics::describe_counter!(ROUTER_CALLS, metrics::Unit::Count, ROUTER_CALLS_HELP);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,4 @@
-use metrics::{counter, gauge, Counter, Gauge};
+use metrics::{counter, gauge, histogram, Counter, Gauge, Histogram};
 use std::sync::LazyLock;
 
 /// Metric name for counting router calls.
@@ -45,6 +45,11 @@ pub(crate) const ACTIVE_CALLS_HELP: &str = "Number of active calls being process
 pub(crate) const COMPLETED_CALLS: &str = "ajj.router.completed_calls";
 pub(crate) const COMPLETED_CALLS_HELP: &str = "Number of completed calls handled";
 
+/// Metric for the uncompressed size in bytes of messages received from and sent to clients.
+pub(crate) const ROUTER_MESSAGE_SIZE: &str = "ajj.router.message_size_bytes";
+pub(crate) const ROUTER_MESSAGE_SIZE_HELP: &str =
+    "Uncompressed size in bytes of JSON-RPC messages received from and sent to clients.";
+
 static DESCRIBE: LazyLock<()> = LazyLock::new(|| {
     metrics::describe_counter!(ROUTER_CALLS, metrics::Unit::Count, ROUTER_CALLS_HELP);
     metrics::describe_counter!(ROUTER_ERRORS, metrics::Unit::Count, ROUTER_ERRORS_HELP);
@@ -75,6 +80,11 @@ static DESCRIBE: LazyLock<()> = LazyLock::new(|| {
     );
     metrics::describe_gauge!(ACTIVE_CALLS, metrics::Unit::Count, ACTIVE_CALLS_HELP);
     metrics::describe_counter!(COMPLETED_CALLS, metrics::Unit::Count, COMPLETED_CALLS_HELP);
+    metrics::describe_histogram!(
+        ROUTER_MESSAGE_SIZE,
+        metrics::Unit::Bytes,
+        ROUTER_MESSAGE_SIZE_HELP
+    );
 });
 
 /// Get or register a counter for calls to a specific service and method.
@@ -243,4 +253,24 @@ fn record_completed_call(service_name: &'static str, method: &str) {
     let _ = &DESCRIBE;
     let counter = completed_calls(service_name, method);
     counter.increment(1);
+}
+
+/// Get or register a histogram for message sizes on a specific service and direction.
+fn message_size(service_name: &'static str, direction: &'static str) -> Histogram {
+    let _ = &DESCRIBE;
+    histogram!(
+        ROUTER_MESSAGE_SIZE,
+        "service" => service_name.to_string(),
+        "direction" => direction,
+    )
+}
+
+/// Record the uncompressed size in bytes of a message sent or received on a service.
+pub(crate) fn record_message_size(
+    service_name: &'static str,
+    direction: &'static str,
+    bytes: usize,
+) {
+    let histogram = message_size(service_name, direction);
+    histogram.record(bytes as f64);
 }

--- a/src/pubsub/shared.rs
+++ b/src/pubsub/shared.rs
@@ -148,6 +148,7 @@ impl ConnectionManager {
             items: rx,
             connection,
             tx_msg_id: self.tx_msg_id.clone(),
+            service_name: self.router.service_name(),
         };
 
         (rt, wt)
@@ -272,6 +273,7 @@ where
                     span.in_scope(|| {
                         message_event!(
                             @received,
+                            service: router.service_name(),
                             counter: &rx_msg_id,
                             bytes: item_bytes,
                         );
@@ -334,6 +336,9 @@ struct WriteTask<T: Listener> {
 
     /// Counter for OTEL messages sent.
     pub(crate) tx_msg_id: Arc<AtomicU32>,
+
+    /// Service name, used to tag the `ajj.router.message_size_bytes` histogram.
+    pub(crate) service_name: &'static str,
 }
 
 impl<T: Listener> WriteTask<T> {
@@ -351,6 +356,7 @@ impl<T: Listener> WriteTask<T> {
             mut items,
             mut connection,
             tx_msg_id,
+            service_name,
             ..
         } = self;
 
@@ -370,6 +376,7 @@ impl<T: Listener> WriteTask<T> {
                     span.in_scope(|| {
                         message_event!(
                             @sent,
+                            service: service_name,
                             counter: &tx_msg_id,
                             bytes: json.get().len(),
                         );


### PR DESCRIPTION
## Summary

Fixes [ENG-2158](https://linear.app/init4/issue/ENG-2158). The `ajj::axum` `rpc.message` event was emitted at `info!` for every inbound and outbound message, producing ~1.69M info logs/hr on signet-sidecar mainnet. Every entry was the same shape: an id, `RECEIVED`/`SENT`, and an uncompressed byte size.

This PR:

- Demotes `message_event!` from `info!` to `trace!`. Per-message events are high-frequency and belong behind `trace`, not `debug` (anyone enabling `debug` on `ajj` for unrelated diagnostics would otherwise be flooded). OTel semantic conventions describe the span-event, they don't mandate a log level.
- Adds an `ajj.router.message_size_bytes` histogram so operators don't lose size visibility. Labels: `service`, `direction` (`RECEIVED`/`SENT`), matching the existing `ajj.router.*` metric family which already tags by `service`.
- Threads `service` through the `message_event!` macro. `RouteTask` already had `router` in scope; `WriteTask` gained a `service_name: &'static str` field populated from the router at `ConnectionManager::make_tasks`.
- Updates the CODEOWNERS file in line with other repos.

## Versioning

0.7.0 -> 0.7.1 (patch). No API changes. The log-level demotion is a behaviour change but not a breaking interface change, and the histogram is additive.
